### PR TITLE
Change template script type to application/javascript

### DIFF
--- a/templates/errors.haml
+++ b/templates/errors.haml
@@ -1,4 +1,4 @@
-<script type="text/template" id="reload-needed">
+<script type="application/javascript" id="reload-needed">
 %div.jumbotron
   %h1.text-center
     New version detected, reloading ...
@@ -6,7 +6,7 @@
 </script>
 
 
-<script type="text/template" id="update-error">
+<script type="application/javascript" id="update-error">
 %div.jumbotron
   %h1.text-center
     =error
@@ -23,7 +23,7 @@
 </script>
 
 
-<script type="text/template" id="fatal-error">
+<script type="application/javascript" id="fatal-error">
 %div.jumbotron
   %h1.text-center
     Critical error
@@ -40,7 +40,7 @@
 </script>
 
 
-<script type="text/template" id="internal-error">
+<script type="application/javascript" id="internal-error">
 %div.jumbotron
   %h1.text-center
     Internal error

--- a/templates/groups.haml
+++ b/templates/groups.haml
@@ -1,4 +1,4 @@
-<script type="text/template" id="groups">
+<script type="application/javascript" id="groups">
 %div.incident{id: group.id, 'data-hash': group.hash}
   -var cls_panel = 'panel-success';
   -if (group.unsilencedCount > 0) {

--- a/templates/modal.haml
+++ b/templates/modal.haml
@@ -1,4 +1,4 @@
-<script type="text/template" id="modal-title">
+<script type="application/javascript" id="modal-title">
   %button.close{type: "button", "data-dismiss": "modal"}
     %i.fa.fa-close
   %div.label-list.label{class: attrs.class, style: attrs.style}
@@ -7,7 +7,7 @@
     =counter
 </script>
 
-<script type="text/template" id="modal-body">
+<script type="application/javascript" id="modal-body">
   %table.table.table-striped
     %caption.text-center
       Quick filters

--- a/templates/summary.haml
+++ b/templates/summary.haml
@@ -1,11 +1,11 @@
-<script type="text/template" id="breakdown">
+<script type="application/javascript" id="breakdown">
 %div.popover
   %div.arrow
   %h1.popover-title.text-center
   %div.popover-content{id: 'breakdown-content'}
 </script>
 
-<script type="text/template" id="breakdown-content">
+<script type="application/javascript" id="breakdown-content">
 -if (tags.length > 0) {
   %table.table
     -$.each(tags, function(i, tag) {


### PR DESCRIPTION
Go 1.8 introduced checking of script type and templates are no longer loading, as the script type is not allowed by Go 1.8
https://github.com/golang/go/issues/18569 captures the details.
Change template script type to one of the allowed types, it doesn't matter for clientside-haml-js, it only needs to match the script id