### PR TITLE
Use Go 1.8 for the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine3.5
+FROM golang:1.8.0-alpine
 
 ADD . /go/src/github.com/cloudflare/unsee
 


### PR DESCRIPTION
Current image uses Go 1.7.5, there was an issue with haml templates preventing us from using 1.8 but it was fixed, so we should switch to latest Go version