### PR TITLE
Add a config file for travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+
+go:
+  - 1.7.5
+  - 1.8
+
+go_import_path: github.com/cloudflare/unsee
+
+script:
+  - make test


### PR DESCRIPTION
This enables travis-ci.org integration, travis will run 'make test' for new PRs

CI job for this PR - https://travis-ci.org/cloudflare/unsee/

Sadly there's an issue - golang/go/issues/12933 and https://github.com/travis-ci/travis-ci/issues/5806 - travis get's rate limited when cloning the repo. I guess we should reconsider checking in vendor dir if there's no workaround soon.