### PR TITLE
Fix 'make vendor-update' to work as documented

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ vendor: .build/vendor.ok
 
 .PHONY: vendor-update
 vendor-update: .build/vendor.ok
-	govendor update +v
+	govendor fetch +v
 
 #======================== asset helper targets =================================
 


### PR DESCRIPTION
make vendor-update should update everything inside the vendor dir, to do this 'govendor fetch' needs to be used, current command ('govendor update') is used to copy packages from /home/lukasz/work/go to vendor dir