### PR TITLE
Fix transport package

### DIFF
--- a/transport/file.go
+++ b/transport/file.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"io"
 	"os"
 
 	log "github.com/Sirupsen/logrus"
@@ -8,9 +9,20 @@ import (
 
 type fileReader struct {
 	filename string
+	fd       *os.File
 }
 
-func newFileReader(filname string) (*os.File, error) {
+func (fr *fileReader) Read(b []byte) (n int, err error) {
+	return fr.fd.Read(b)
+}
+
+func (fr *fileReader) Close() error {
+	return fr.fd.Close()
+}
+
+func newFileReader(filname string) (io.ReadCloser, error) {
 	log.Infof("Reading file '%s'", filname)
-	return os.Open(filname)
+	fd, err := os.Open(filname)
+	fr := fileReader{filename: filname, fd: fd}
+	return &fr, err
 }

--- a/transport/http.go
+++ b/transport/http.go
@@ -15,7 +15,7 @@ type httpReader struct {
 	Timeout time.Duration
 }
 
-func newHTTPReader(url string, timeout time.Duration) (*io.ReadCloser, error) {
+func newHTTPReader(url string, timeout time.Duration) (io.ReadCloser, error) {
 	hr := httpReader{URL: url, Timeout: timeout}
 
 	log.Infof("GET %s timeout=%s", hr.URL, hr.Timeout)
@@ -38,8 +38,6 @@ func newHTTPReader(url string, timeout time.Duration) (*io.ReadCloser, error) {
 		return nil, fmt.Errorf("Request to Alertmanager failed with %s", resp.Status)
 	}
 
-	defer resp.Body.Close()
-
 	var reader io.ReadCloser
 	switch resp.Header.Get("Content-Encoding") {
 	case "gzip":
@@ -47,9 +45,8 @@ func newHTTPReader(url string, timeout time.Duration) (*io.ReadCloser, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Failed to decode gzipped content: %s", err.Error())
 		}
-		defer reader.Close()
 	default:
 		reader = resp.Body
 	}
-	return &reader, nil
+	return reader, nil
 }


### PR DESCRIPTION
Transport refactoring introduced a bug where HTTP(S) response body is closed before it's fully read (depending on whenever gzip is used or not), this change fixes it and makes the code easier to follow by removing duplicated code and enforcing all transport packages to implement ReaderCloser interface.