### PR TITLE
Drop Go master tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ language: go
 go:
   - 1.7.x
   - 1.8.x
-  - master
-
-matrix:
-  allow_failures:
-    - go: master
 
 go_import_path: github.com/cloudflare/unsee
 


### PR DESCRIPTION
Master takes 2-3x longer than usual builds, slowing down CI checks, release builds take <1m while master can take >3m (https://travis-ci.org/cloudflare/unsee/builds/222971729)