### PR TITLE
Put the branch name first on the version string for docker master builds

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -13,7 +13,7 @@ else
   # for everything else generate version from branch name and git tag/commit
   # it would be best to use SOURCE_COMMIT here, but it doesn't work
   # see https://github.com/docker/hub-feedback/issues/600
-  VERSION=$(git describe --tags --always)-${SOURCE_BRANCH}
+  VERSION=${SOURCE_BRANCH}-$(git describe --always)
 fi
 
 docker build --build-arg VERSION=${VERSION} -t ${IMAGE_NAME} .


### PR DESCRIPTION
Docker Hub makes a shallow clone of the git repo, so we don't have tags anyway, we end up with commit-master (e.g. 289f849-master), put the branch first so it's more human readable (master-289f849)