### PR TITLE
Add basic support for Alertmanager 0.6.1

### DIFF
--- a/alertmanager/alertmanager.go
+++ b/alertmanager/alertmanager.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cloudflare/unsee/mapper"
 	"github.com/cloudflare/unsee/mapper/v04"
 	"github.com/cloudflare/unsee/mapper/v05"
+	"github.com/cloudflare/unsee/mapper/v061"
 	"github.com/cloudflare/unsee/models"
 
 	log "github.com/Sirupsen/logrus"
@@ -15,6 +16,7 @@ import (
 func init() {
 	mapper.RegisterAlertMapper(v04.AlertMapper{})
 	mapper.RegisterAlertMapper(v05.AlertMapper{})
+	mapper.RegisterAlertMapper(v061.AlertMapper{})
 	mapper.RegisterSilenceMapper(v04.SilenceMapper{})
 	mapper.RegisterSilenceMapper(v05.SilenceMapper{})
 }


### PR DESCRIPTION
This makes unsee work with 0.6.1, but the new status means that we should refactor unsee data model and pull inhibited and silenced into it, with a single filter.