### PR TITLE
More strict filter validation

### DIFF
--- a/filters/filter.go
+++ b/filters/filter.go
@@ -96,8 +96,7 @@ func NewFilter(expression string) FilterT {
 	// we have "filter=" part, lookup filter that matches
 	for _, fc := range AllFilters {
 		f := fc.Factory()
-		labelRe := regexp.MustCompile("^(?:" + fc.Label + ")$")
-		if !labelRe.MatchString(matched) {
+		if !fc.LabelRe.MatchString(matched) {
 			// filter name doesn't match, keep searching
 			continue
 		}

--- a/filters/filter_test.go
+++ b/filters/filter_test.go
@@ -406,6 +406,30 @@ var tests = []filterTest{
 		Expression: "^abb[****].*****",
 		IsValid:    false,
 	},
+	filterTest{
+		Expression: "@silenced=true",
+		IsValid:    false,
+	},
+	filterTest{
+		Expression: "@silenced!=false",
+		IsValid:    false,
+	},
+	filterTest{
+		Expression: "@silenced=~false",
+		IsValid:    false,
+	},
+	filterTest{
+		Expression: "@inhibited=true",
+		IsValid:    false,
+	},
+	filterTest{
+		Expression: "@inhibited!=false",
+		IsValid:    false,
+	},
+	filterTest{
+		Expression: "@inhibited=~false",
+		IsValid:    false,
+	},
 }
 
 func TestFilters(t *testing.T) {

--- a/filters/registry.go
+++ b/filters/registry.go
@@ -1,5 +1,7 @@
 package filters
 
+import "regexp"
+
 const (
 	equalOperator         string = "="
 	notEqualOperator      string = "!="
@@ -29,6 +31,7 @@ var matcherConfig = map[string]matcherT{
 
 type filterConfig struct {
 	Label              string
+	LabelRe            *regexp.Regexp
 	SupportedOperators []string
 	Factory            newFilterFactory
 	Autocomplete       autocompleteFactory
@@ -39,36 +42,42 @@ type filterConfig struct {
 var AllFilters = []filterConfig{
 	filterConfig{
 		Label:              "@status",
+		LabelRe:            regexp.MustCompile("^@status$"),
 		SupportedOperators: []string{equalOperator, notEqualOperator},
 		Factory:            newstatusFilter,
 		Autocomplete:       statusAutocomplete,
 	},
 	filterConfig{
 		Label:              "@age",
+		LabelRe:            regexp.MustCompile("^@age$"),
 		SupportedOperators: []string{lessThanOperator, moreThanOperator},
 		Factory:            newAgeFilter,
 		Autocomplete:       ageAutocomplete,
 	},
 	filterConfig{
 		Label:              "@silence_jira",
+		LabelRe:            regexp.MustCompile("^@silence_jira$"),
 		SupportedOperators: []string{regexpOperator, negativeRegexOperator, equalOperator, notEqualOperator},
 		Factory:            newSilenceJiraFilter,
 		Autocomplete:       sinceJiraIDAutocomplete,
 	},
 	filterConfig{
 		Label:              "@silence_author",
+		LabelRe:            regexp.MustCompile("^@silence_author$"),
 		SupportedOperators: []string{regexpOperator, negativeRegexOperator, equalOperator, notEqualOperator},
 		Factory:            newSilenceAuthorFilter,
 		Autocomplete:       sinceAuthorAutocomplete,
 	},
 	filterConfig{
 		Label:              "@limit",
+		LabelRe:            regexp.MustCompile("^@limit$"),
 		SupportedOperators: []string{equalOperator},
 		Factory:            newLimitFilter,
 		Autocomplete:       limitAutocomplete,
 	},
 	filterConfig{
 		Label:              "[a-zA-Z_][a-zA-Z0-9_]*",
+		LabelRe:            regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$"),
 		SupportedOperators: []string{regexpOperator, negativeRegexOperator, equalOperator, notEqualOperator, lessThanOperator, moreThanOperator},
 		Factory:            newLabelFilter,
 		Autocomplete:       labelAutocomplete,

--- a/filters/registry.go
+++ b/filters/registry.go
@@ -15,6 +15,9 @@ const (
 // a===b should yield an error
 var matcherRegex = "[=!<>~]+"
 
+// same as matcherRegex but for the filter name part
+var filterRegex = "^(@)?[a-zA-Z_][a-zA-Z0-9_]*"
+
 var matcherConfig = map[string]matcherT{
 	equalOperator:         &equalMatcher{},
 	notEqualOperator:      &notEqualMatcher{},
@@ -25,7 +28,6 @@ var matcherConfig = map[string]matcherT{
 }
 
 type filterConfig struct {
-	IsSimple           bool
 	Label              string
 	SupportedOperators []string
 	Factory            newFilterFactory
@@ -70,9 +72,5 @@ var AllFilters = []filterConfig{
 		SupportedOperators: []string{regexpOperator, negativeRegexOperator, equalOperator, notEqualOperator, lessThanOperator, moreThanOperator},
 		Factory:            newLabelFilter,
 		Autocomplete:       labelAutocomplete,
-	},
-	filterConfig{
-		IsSimple: true,
-		Factory:  newFuzzyFilter,
 	},
 }


### PR DESCRIPTION
`@silenced=true` should now be marked as invalid filter, but it isn't, this commit refactors it so that instead of looping over all filters and falling back to fuzzy (which is very relaxed checking and can't find typos in filter names like `@statuz=active`) we tokenize the expression into '<filter name> <operator> <value>' and only fallback to fuzzy if there's only a static text (no filter name and operator). This is more manual but provides stronger checks so now `@silenced=true` is correctly marked as invalid.