### PR TITLE
Fix race condition in the matcher code

### DIFF
--- a/filters/matcher.go
+++ b/filters/matcher.go
@@ -123,7 +123,6 @@ func (matcher *negativeRegexMatcher) Compare(valA, valB interface{}) bool {
 
 func newMatcher(matchType string) (matcherT, error) {
 	if m, found := matcherConfig[matchType]; found {
-		m.setOperator(matchType)
 		return m, nil
 	}
 	e := fmt.Sprintf("%s not matched with any know match type", matchType)

--- a/filters/matcher.go
+++ b/filters/matcher.go
@@ -23,10 +23,6 @@ type abstractMatcher struct {
 	Operator string
 }
 
-func (matcher *abstractMatcher) setOperator(operator string) {
-	matcher.Operator = operator
-}
-
 func (matcher *abstractMatcher) GetOperator() string {
 	return matcher.Operator
 }

--- a/filters/registry.go
+++ b/filters/registry.go
@@ -21,12 +21,12 @@ var matcherRegex = "[=!<>~]+"
 var filterRegex = "^(@)?[a-zA-Z_][a-zA-Z0-9_]*"
 
 var matcherConfig = map[string]matcherT{
-	equalOperator:         &equalMatcher{},
-	notEqualOperator:      &notEqualMatcher{},
-	moreThanOperator:      &moreThanMatcher{},
-	lessThanOperator:      &lessThanMatcher{},
-	regexpOperator:        &regexpMatcher{},
-	negativeRegexOperator: &negativeRegexMatcher{},
+	equalOperator:         &equalMatcher{abstractMatcher{Operator: equalOperator}},
+	notEqualOperator:      &notEqualMatcher{abstractMatcher{Operator: notEqualOperator}},
+	moreThanOperator:      &moreThanMatcher{abstractMatcher{Operator: moreThanOperator}},
+	lessThanOperator:      &lessThanMatcher{abstractMatcher{Operator: lessThanOperator}},
+	regexpOperator:        &regexpMatcher{abstractMatcher{Operator: regexpOperator}},
+	negativeRegexOperator: &negativeRegexMatcher{abstractMatcher{Operator: negativeRegexOperator}},
 }
 
 type filterConfig struct {


### PR DESCRIPTION
We have a static list of matchers, one for each kind, but newMatcher() was writing to those on every filter creation. Remove writes, set the attribute on matcher init instead.