### PR TITLE
Speed up alert fingerprint generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ endif
 
 .PHONY: test
 test: lint bindata_assetfs.go
-	go test -cover `go list ./... | grep -v /vendor/`
+	go test -bench=. -cover `go list ./... | grep -v /vendor/`
 
 .build/vendor.ok:
 	go get -u github.com/kardianos/govendor

--- a/alertmanager/models.go
+++ b/alertmanager/models.go
@@ -168,6 +168,8 @@ func (am *Alertmanager) pullAlerts(version string) error {
 			for k, v := range alert.Labels {
 				transform.ColorLabel(colors, k, v)
 			}
+
+			alert.UpdateFingerprints()
 			alerts = append(alerts, alert)
 
 			// update internal metrics

--- a/models/alert_test.go
+++ b/models/alert_test.go
@@ -2,6 +2,7 @@ package models_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/cloudflare/unsee/models"
 )
@@ -50,5 +51,51 @@ func TestAlertState(t *testing.T) {
 			t.Errorf("alert.IsSilenced() returned %t while %t was expected for alert %v",
 				testCase.alert.IsSilenced(), testCase.isSilenced, testCase.alert)
 		}
+	}
+}
+
+func BenchmarkLabelsFingerprint(b *testing.B) {
+	alert := models.Alert{
+		Labels: map[string]string{
+			"foo1":        "bar1",
+			"foo1bar1":    "545jjjssd",
+			"foo1xxxx":    "bdjjs88ff",
+			"agdfdfd":     "bar1",
+			"fossdsf3o1":  "bar11111",
+			"fdfdgfdgoo1": "bar1",
+		},
+	}
+	for n := 0; n < b.N; n++ {
+		alert.LabelsFingerprint()
+	}
+}
+
+func BenchmarkLabelsContent(b *testing.B) {
+	alert := models.Alert{
+		Annotations: map[string]string{
+			"foo": "bar",
+			"abc": "Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit...",
+		},
+		Labels: map[string]string{
+			"foo1":        "bar1",
+			"foo1bar1":    "545jjjssd",
+			"foo1xxxx":    "bdjjs88ff",
+			"agdfdfd":     "bar1",
+			"fossdsf3o1":  "bar11111",
+			"fdfdgfdgoo1": "bar1",
+		},
+		State:    models.AlertStateActive,
+		StartsAt: time.Date(2015, time.March, 10, 0, 0, 0, 0, time.UTC),
+		Alertmanager: []models.AlertmanagerInstance{
+			models.AlertmanagerInstance{
+				Name:  "default",
+				URI:   "http://localhost",
+				State: models.AlertStateActive,
+			},
+		},
+	}
+	alert.UpdateFingerprints()
+	for n := 0; n < b.N; n++ {
+		alert.LabelsFingerprint()
 	}
 }

--- a/models/alertgroup_test.go
+++ b/models/alertgroup_test.go
@@ -47,6 +47,7 @@ var alertListSortTests = []alertListSortTest{
 func TestUnseeAlertListSort(t *testing.T) {
 	al := models.AlertList{}
 	for _, testCase := range alertListSortTests {
+		testCase.alert.UpdateFingerprints()
 		al = append(al, testCase.alert)
 	}
 
@@ -56,6 +57,7 @@ func TestUnseeAlertListSort(t *testing.T) {
 	for i := 1; i <= iterations; i++ {
 		sort.Sort(al)
 		for _, testCase := range alertListSortTests {
+			testCase.alert.UpdateFingerprints()
 			if al[testCase.position].ContentFingerprint() != testCase.alert.ContentFingerprint() {
 				failures++
 			}
@@ -120,6 +122,13 @@ var agFPTests = []agFPTest{
 
 func TestAlertGroupContentFingerprint(t *testing.T) {
 	for _, testCase := range agFPTests {
+		alerts := models.AlertList{}
+		for _, alert := range testCase.ag.Alerts {
+			alert.UpdateFingerprints()
+			alerts = append(alerts, alert)
+		}
+		sort.Sort(alerts)
+		testCase.ag.Alerts = alerts
 		if testCase.ag.ContentFingerprint() != testCase.fingerprint {
 			t.Errorf("Invalid AlertGroup ContentFingerprint(), expected '%s', got '%s', AlertGroup: %v",
 				testCase.fingerprint, testCase.ag.ContentFingerprint(), testCase.ag)

--- a/views.go
+++ b/views.go
@@ -133,6 +133,11 @@ func alerts(c *gin.Context) {
 			}
 			if !validFilters || (slices.BoolInSlice(results, true) && !slices.BoolInSlice(results, false)) {
 				matches++
+				// we need to update fingerprints since we've modified some fields in dedup
+				// and agCopy.ContentFingerprint() depends on per alert fingerprint
+				// we update it here rather than in dedup since here we can apply it
+				// only for alerts left after filtering
+				alert.UpdateFingerprints()
 				agCopy.Alerts = append(agCopy.Alerts, alert)
 
 				countLabel(counters, "@state", alert.State)


### PR DESCRIPTION
Dynamic fingerprints made the code much slower, pprof shows they are responsible for ~70% of all cpu usage for any API call. To make it worse they are applied to all alerts, since dedup layer doesn't know which alerts will be filtered later, it operates on all of them. This PR will:
1. add benchmarks to so it's easier to track performance
2. Keep current methods for accessing fingerprints, but use precomputed static fields in those
3. Refactor Alert methods to use pointers, so we're not working on a copy

Benchmark timing went down from ~4000ns to 0.4ns for fingerprint calls and API response times from 1.3s (for my test sample) to 0.2s, which puts it back to the same level as before moving fingerprints to be dynamic. I still don't like this code much, it's all over the place, but I don't have a good idea how to better structure this, let's hope I'll be wiser in the future.