### PR TITLE
Refactor Makefile targets to make it easier to add build tool deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,15 +25,27 @@ ESLINT := $(shell which eslint)
 
 .DEFAULT_GOAL := $(NAME)
 
-.build/deps.ok:
+.build/go-bindata:
+	@mkdir -p .build
 	go get -u github.com/jteeuwen/go-bindata/...
+	touch $@
+
+.build/go-bindata-assetfs:
+	@mkdir -p .build
 	go get -u github.com/elazarl/go-bindata-assetfs/...
+	touch $@
+
+.build/golint:
+	@mkdir -p .build
 	go get -u github.com/golang/lint/golint
-	mkdir -p .build
+	touch $@
+
+.build/deps.ok: .build/go-bindata .build/go-bindata-assetfs .build/golint
+	@mkdir -p .build
 	touch $@
 
 .build/bindata_assetfs.%:
-	mkdir -p .build
+	@mkdir -p .build
 	rm -f .build/bindata_assetfs.*
 	touch $@
 
@@ -92,7 +104,7 @@ test: lint bindata_assetfs.go
 
 .build/vendor.ok:
 	go get -u github.com/kardianos/govendor
-	mkdir -p .build
+	@mkdir -p .build
 	touch $@
 
 .PHONY: vendor


### PR DESCRIPTION
If I would add a new 'go get foo' line in the build/deps.ok target it wouldn't install anything since the file we touch at the end already exist. Split all 'go get foo' lines into dedicated targets and make build/deps.ok depend on it. This way when you add a new build time dependency make will be able to do the magic and just install what's missing.
I made those change to add github.com/cespare/prettybench, it ended up adding little value so I dropped it, but Makefile refactor still seems like a good idea