### PR TITLE
Re-implement metrics calculation as a collector

### DIFF
--- a/alertmanager/metrics.go
+++ b/alertmanager/metrics.go
@@ -2,40 +2,120 @@ package alertmanager
 
 import "github.com/prometheus/client_golang/prometheus"
 
-var (
-	metricAlerts = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "unsee_collected_alerts",
-			Help: "Total number of alerts collected from Alertmanager API",
-		},
-		[]string{"alertmanager", "state"},
-	)
-	metricAlertGroups = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "unsee_collected_groups",
-			Help: "Total number of alert groups collected from Alertmanager API",
-		},
-		[]string{"alertmanager"},
-	)
-	metricAlertmanagerErrors = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "unsee_alertmanager_errors_total",
-			Help: "Total number of errors encounter when requesting data from Alertmanager API",
-		},
-		[]string{"alertmanager", "endpoint"},
-	)
-	metricCollectRuns = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "unsee_collect_cycles_total",
-			Help: "Total number of alert collection cycles run",
-		},
-		[]string{"alertmanager"},
-	)
-)
+type unseeCollector struct {
+	collectedAlerts *prometheus.Desc
+	collectedGroups *prometheus.Desc
+	cyclesTotal     *prometheus.Desc
+	errorsTotal     *prometheus.Desc
+}
+
+func newUnseeCollector() *unseeCollector {
+	return &unseeCollector{
+		collectedAlerts: prometheus.NewDesc(
+			"unsee_collected_alerts_count",
+			"Total number of alerts collected from Alertmanager API",
+			[]string{"alertmanager", "state", "receiver"},
+			prometheus.Labels{},
+		),
+		collectedGroups: prometheus.NewDesc(
+			"unsee_collected_groups_count",
+			"Total number of alert groups collected from Alertmanager API",
+			[]string{"alertmanager", "receiver"},
+			prometheus.Labels{},
+		),
+		cyclesTotal: prometheus.NewDesc(
+			"unsee_collect_cycles_total",
+			"Total number of alert collection cycles run",
+			[]string{"alertmanager"},
+			prometheus.Labels{},
+		),
+		errorsTotal: prometheus.NewDesc(
+			"unsee_alertmanager_errors_total",
+			"Total number of errors encounter when requesting data from Alertmanager API",
+			[]string{"alertmanager", "endpoint"},
+			prometheus.Labels{},
+		),
+	}
+}
+
+func (c *unseeCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.collectedAlerts
+	ch <- c.collectedGroups
+	ch <- c.cyclesTotal
+	ch <- c.errorsTotal
+}
+
+func (c *unseeCollector) Collect(ch chan<- prometheus.Metric) {
+	upstreams := GetAlertmanagers()
+
+	for _, am := range upstreams {
+
+		ch <- prometheus.MustNewConstMetric(
+			c.cyclesTotal,
+			prometheus.CounterValue,
+			am.metrics.cycles,
+			am.Name,
+		)
+		for key, val := range am.metrics.errors {
+			ch <- prometheus.MustNewConstMetric(
+				c.errorsTotal,
+				prometheus.CounterValue,
+				val,
+				am.Name,
+				key,
+			)
+		}
+
+		// receiver name -> count
+		groupsByReceiver := map[string]float64{}
+		// receiver name -> state -> count
+		alertsByReceiverByState := map[string]map[string]float64{}
+
+		// iterate all alert groups this instance stores
+		for _, group := range am.Alerts() {
+			// count all groups per receiver
+			if _, found := groupsByReceiver[group.Receiver]; !found {
+				groupsByReceiver[group.Receiver] = 0
+			}
+			groupsByReceiver[group.Receiver]++
+
+			// count all alerts per receiver & state
+			for _, alert := range group.Alerts {
+				if _, found := alertsByReceiverByState[alert.Receiver]; !found {
+					alertsByReceiverByState[alert.Receiver] = map[string]float64{}
+				}
+				if _, found := alertsByReceiverByState[alert.Receiver][alert.State]; !found {
+					alertsByReceiverByState[alert.Receiver][alert.State] = 0
+				}
+				alertsByReceiverByState[alert.Receiver][alert.State]++
+			}
+		}
+
+		// publish metrics using calculated values
+		for reciver, count := range groupsByReceiver {
+			ch <- prometheus.MustNewConstMetric(
+				c.collectedGroups,
+				prometheus.GaugeValue,
+				count,
+				am.Name,
+				reciver,
+			)
+		}
+		for reciver, byState := range alertsByReceiverByState {
+			for state, count := range byState {
+				ch <- prometheus.MustNewConstMetric(
+					c.collectedAlerts,
+					prometheus.GaugeValue,
+					count,
+					am.Name,
+					reciver,
+					state,
+				)
+			}
+		}
+	}
+}
 
 func init() {
-	prometheus.MustRegister(metricAlerts)
-	prometheus.MustRegister(metricAlertGroups)
-	prometheus.MustRegister(metricAlertmanagerErrors)
-	prometheus.MustRegister(metricCollectRuns)
+	prometheus.MustRegister(newUnseeCollector())
 }

--- a/alertmanager/upstream.go
+++ b/alertmanager/upstream.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/cloudflare/unsee/models"
-	"github.com/prometheus/client_golang/prometheus"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -27,16 +26,6 @@ func NewAlertmanager(name, uri string, timeout time.Duration) error {
 		}
 	}
 
-	// initialize metrics
-	metricAlertmanagerErrors.With(prometheus.Labels{
-		"alertmanager": name,
-		"endpoint":     "alerts",
-	}).Set(0)
-	metricAlertmanagerErrors.With(prometheus.Labels{
-		"alertmanager": name,
-		"endpoint":     "silences",
-	}).Set(0)
-
 	upstreams[name] = &Alertmanager{
 		URI:          uri,
 		Timeout:      timeout,
@@ -46,6 +35,12 @@ func NewAlertmanager(name, uri string, timeout time.Duration) error {
 		silences:     map[string]models.Silence{},
 		colors:       models.LabelsColorMap{},
 		autocomplete: []models.Autocomplete{},
+		metrics: alertmanagerMetrics{
+			errors: map[string]float64{
+				labelValueErrorsAlerts:   0,
+				labelValueErrorsSilences: 0,
+			},
+		},
 	}
 
 	log.Infof("[%s] Configured Alertmanager source at %s", name, uri)


### PR DESCRIPTION
Split metrics code into a collector, this way it's self contained and doesn't require mixing metric calculation in the main logic.
Fixes #130