### PR TITLE
Alertmanager 0.8.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ NAME    := unsee
 VERSION := $(shell git describe --tags --always --dirty='-dev')
 
 # Alertmanager instance used when running locally, points to mock data
-MOCK_PATH         := $(CURDIR)/mock/0.7.1
+MOCK_PATH         := $(CURDIR)/mock/0.8.0
 ALERTMANAGER_URIS := "mock:file://$(MOCK_PATH)"
 # Listen port when running locally
 PORT := 8080

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ _RSS to email_ notifications, like [Blogtrottr](https://blogtrottr.com/).
 
 ## Supported Alertmanager versions
 
-Alertmanager's API isn't stable yet and can change between releases.
-unsee currently supports Alertmanager `0.4`, `0.5`, `0.6` and `0.7`.
+Alertmanager's API isn't stable yet and can change between releases,
+see `VERSIONS` in [mock/Makefile](/mock/Makefile) for list of all Alertmanager
+releases that are tested and supported by unsee.
 Due to API differences between those releases some features will work
 differently or be missing, it's recommended to use the latest supported
 Alertmanager version.

--- a/mock/0.8.0/api/v1/alerts/groups
+++ b/mock/0.8.0/api/v1/alerts/groups
@@ -1,0 +1,741 @@
+{
+    "data": [
+        {
+            "blocks": [
+                {
+                    "alerts": [
+                        {
+                            "annotations": {
+                                "alert": "Less than 10% disk space is free",
+                                "dashboard": "http://localhost/dashboard.html"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Free_Disk_Space_Too_Low",
+                                "cluster": "staging",
+                                "instance": "server5",
+                                "job": "node_exporter"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        }
+                    ],
+                    "routeOpts": {
+                        "groupBy": [
+                            "alertname"
+                        ],
+                        "groupInterval": 35000000000,
+                        "groupWait": 15000000000,
+                        "receiver": "by-name",
+                        "repeatInterval": 3596400000000000
+                    }
+                }
+            ],
+            "groupKey": "{}/{alertname=~\"^(?:.*)$\"}:{alertname=\"Free_Disk_Space_Too_Low\"}",
+            "labels": {
+                "alertname": "Free_Disk_Space_Too_Low"
+            }
+        },
+        {
+            "blocks": [
+                {
+                    "alerts": [
+                        {
+                            "annotations": {
+                                "help": "Example help annotation",
+                                "summary": "Example summary",
+                                "url": "http://localhost/example.html"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "HTTP_Probe_Failed",
+                                "cluster": "dev",
+                                "instance": "web1",
+                                "job": "node_exporter"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "c5d3eb33-90eb-4432-8cb8-8b4ee7147583"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "HTTP_Probe_Failed",
+                                "cluster": "dev",
+                                "instance": "web2",
+                                "job": "node_exporter"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        }
+                    ],
+                    "routeOpts": {
+                        "groupBy": [
+                            "alertname"
+                        ],
+                        "groupInterval": 35000000000,
+                        "groupWait": 15000000000,
+                        "receiver": "by-name",
+                        "repeatInterval": 3596400000000000
+                    }
+                }
+            ],
+            "groupKey": "{}/{alertname=~\"^(?:.*)$\"}:{alertname=\"HTTP_Probe_Failed\"}",
+            "labels": {
+                "alertname": "HTTP_Probe_Failed"
+            }
+        },
+        {
+            "blocks": [
+                {
+                    "alerts": [
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server5",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server6",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "dde04358-fe29-46b9-8a0c-f26e055b3a6a"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server7",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "dde04358-fe29-46b9-8a0c-f26e055b3a6a",
+                                    "ac1f139b-e42b-4e22-9732-715d17e6223c"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server8",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "dde04358-fe29-46b9-8a0c-f26e055b3a6a"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary",
+                                "url": "http://localhost/example.html"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "prod",
+                                "instance": "server1",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "prod",
+                                "instance": "server2",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server3",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server4",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        }
+                    ],
+                    "routeOpts": {
+                        "groupBy": [
+                            "alertname"
+                        ],
+                        "groupInterval": 35000000000,
+                        "groupWait": 15000000000,
+                        "receiver": "by-name",
+                        "repeatInterval": 3596400000000000
+                    }
+                }
+            ],
+            "groupKey": "{}/{alertname=~\"^(?:.*)$\"}:{alertname=\"Host_Down\"}",
+            "labels": {
+                "alertname": "Host_Down"
+            }
+        },
+        {
+            "blocks": [
+                {
+                    "alerts": [
+                        {
+                            "annotations": {
+                                "alert": "Memory usage exceeding threshold",
+                                "dashboard": "http://localhost/dashboard.html"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Memory_Usage_Too_High",
+                                "cluster": "prod",
+                                "instance": "server2",
+                                "job": "node_exporter"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        }
+                    ],
+                    "routeOpts": {
+                        "groupBy": [
+                            "alertname"
+                        ],
+                        "groupInterval": 35000000000,
+                        "groupWait": 15000000000,
+                        "receiver": "by-name",
+                        "repeatInterval": 3596400000000000
+                    }
+                }
+            ],
+            "groupKey": "{}/{alertname=~\"^(?:.*)$\"}:{alertname=\"Memory_Usage_Too_High\"}",
+            "labels": {
+                "alertname": "Memory_Usage_Too_High"
+            }
+        },
+        {
+            "blocks": [
+                {
+                    "alerts": [
+                        {
+                            "annotations": {
+                                "alert": "Less than 10% disk space is free",
+                                "dashboard": "http://localhost/dashboard.html"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Free_Disk_Space_Too_Low",
+                                "cluster": "staging",
+                                "instance": "server5",
+                                "job": "node_exporter"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        }
+                    ],
+                    "routeOpts": {
+                        "groupBy": [
+                            "alertname",
+                            "cluster",
+                            "service"
+                        ],
+                        "groupInterval": 35000000000,
+                        "groupWait": 15000000000,
+                        "receiver": "by-cluster-service",
+                        "repeatInterval": 3596400000000000
+                    }
+                }
+            ],
+            "groupKey": "{}/{alertname=~\"^(?:.*)$\"}:{alertname=\"Free_Disk_Space_Too_Low\", cluster=\"staging\"}",
+            "labels": {
+                "alertname": "Free_Disk_Space_Too_Low",
+                "cluster": "staging"
+            }
+        },
+        {
+            "blocks": [
+                {
+                    "alerts": [
+                        {
+                            "annotations": {
+                                "help": "Example help annotation",
+                                "summary": "Example summary",
+                                "url": "http://localhost/example.html"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "HTTP_Probe_Failed",
+                                "cluster": "dev",
+                                "instance": "web1",
+                                "job": "node_exporter"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "c5d3eb33-90eb-4432-8cb8-8b4ee7147583"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "HTTP_Probe_Failed",
+                                "cluster": "dev",
+                                "instance": "web2",
+                                "job": "node_exporter"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        }
+                    ],
+                    "routeOpts": {
+                        "groupBy": [
+                            "alertname",
+                            "cluster",
+                            "service"
+                        ],
+                        "groupInterval": 35000000000,
+                        "groupWait": 15000000000,
+                        "receiver": "by-cluster-service",
+                        "repeatInterval": 3596400000000000
+                    }
+                }
+            ],
+            "groupKey": "{}/{alertname=~\"^(?:.*)$\"}:{alertname=\"HTTP_Probe_Failed\", cluster=\"dev\"}",
+            "labels": {
+                "alertname": "HTTP_Probe_Failed",
+                "cluster": "dev"
+            }
+        },
+        {
+            "blocks": [
+                {
+                    "alerts": [
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server6",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "dde04358-fe29-46b9-8a0c-f26e055b3a6a"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server7",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "dde04358-fe29-46b9-8a0c-f26e055b3a6a",
+                                    "ac1f139b-e42b-4e22-9732-715d17e6223c"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server8",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "dde04358-fe29-46b9-8a0c-f26e055b3a6a"
+                                ],
+                                "state": "suppressed"
+                            }
+                        }
+                    ],
+                    "routeOpts": {
+                        "groupBy": [
+                            "service",
+                            "alertname",
+                            "cluster"
+                        ],
+                        "groupInterval": 35000000000,
+                        "groupWait": 15000000000,
+                        "receiver": "by-cluster-service",
+                        "repeatInterval": 3596400000000000
+                    }
+                }
+            ],
+            "groupKey": "{}/{alertname=~\"^(?:.*)$\"}:{alertname=\"Host_Down\", cluster=\"dev\"}",
+            "labels": {
+                "alertname": "Host_Down",
+                "cluster": "dev"
+            }
+        },
+        {
+            "blocks": [
+                {
+                    "alerts": [
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "prod",
+                                "instance": "server2",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary",
+                                "url": "http://localhost/example.html"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "prod",
+                                "instance": "server1",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        }
+                    ],
+                    "routeOpts": {
+                        "groupBy": [
+                            "alertname",
+                            "cluster",
+                            "service"
+                        ],
+                        "groupInterval": 35000000000,
+                        "groupWait": 15000000000,
+                        "receiver": "by-cluster-service",
+                        "repeatInterval": 3596400000000000
+                    }
+                }
+            ],
+            "groupKey": "{}/{alertname=~\"^(?:.*)$\"}:{alertname=\"Host_Down\", cluster=\"prod\"}",
+            "labels": {
+                "alertname": "Host_Down",
+                "cluster": "prod"
+            }
+        },
+        {
+            "blocks": [
+                {
+                    "alerts": [
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server3",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server4",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server5",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        }
+                    ],
+                    "routeOpts": {
+                        "groupBy": [
+                            "alertname",
+                            "cluster",
+                            "service"
+                        ],
+                        "groupInterval": 35000000000,
+                        "groupWait": 15000000000,
+                        "receiver": "by-cluster-service",
+                        "repeatInterval": 3596400000000000
+                    }
+                }
+            ],
+            "groupKey": "{}/{alertname=~\"^(?:.*)$\"}:{alertname=\"Host_Down\", cluster=\"staging\"}",
+            "labels": {
+                "alertname": "Host_Down",
+                "cluster": "staging"
+            }
+        },
+        {
+            "blocks": [
+                {
+                    "alerts": [
+                        {
+                            "annotations": {
+                                "alert": "Memory usage exceeding threshold",
+                                "dashboard": "http://localhost/dashboard.html"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Memory_Usage_Too_High",
+                                "cluster": "prod",
+                                "instance": "server2",
+                                "job": "node_exporter"
+                            },
+                            "receivers": null,
+                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        }
+                    ],
+                    "routeOpts": {
+                        "groupBy": [
+                            "alertname",
+                            "cluster",
+                            "service"
+                        ],
+                        "groupInterval": 35000000000,
+                        "groupWait": 15000000000,
+                        "receiver": "by-cluster-service",
+                        "repeatInterval": 3596400000000000
+                    }
+                }
+            ],
+            "groupKey": "{}/{alertname=~\"^(?:.*)$\"}:{alertname=\"Memory_Usage_Too_High\", cluster=\"prod\"}",
+            "labels": {
+                "alertname": "Memory_Usage_Too_High",
+                "cluster": "prod"
+            }
+        }
+    ],
+    "status": "success"
+}

--- a/mock/0.8.0/api/v1/silences
+++ b/mock/0.8.0/api/v1/silences
@@ -1,0 +1,64 @@
+{
+    "data": [
+        {
+            "comment": "Silenced instance",
+            "createdBy": "john@example.com",
+            "endsAt": "2063-01-01T00:00:00Z",
+            "id": "c5d3eb33-90eb-4432-8cb8-8b4ee7147583",
+            "matchers": [
+                {
+                    "isRegex": false,
+                    "name": "instance",
+                    "value": "web1"
+                }
+            ],
+            "startsAt": "2017-07-22T01:07:54.312124563Z",
+            "status": {
+                "state": "active"
+            },
+            "updatedAt": "2017-07-22T01:07:54.312131495Z"
+        },
+        {
+            "comment": "Silenced Host_Down alerts in the dev cluster",
+            "createdBy": "john@example.com",
+            "endsAt": "2063-01-01T00:00:00Z",
+            "id": "dde04358-fe29-46b9-8a0c-f26e055b3a6a",
+            "matchers": [
+                {
+                    "isRegex": false,
+                    "name": "alertname",
+                    "value": "Host_Down"
+                },
+                {
+                    "isRegex": false,
+                    "name": "cluster",
+                    "value": "dev"
+                }
+            ],
+            "startsAt": "2017-07-22T01:07:54.314514791Z",
+            "status": {
+                "state": "active"
+            },
+            "updatedAt": "2017-07-22T01:07:54.314518694Z"
+        },
+        {
+            "comment": "Silenced server7",
+            "createdBy": "john@example.com",
+            "endsAt": "2063-01-01T00:00:00Z",
+            "id": "ac1f139b-e42b-4e22-9732-715d17e6223c",
+            "matchers": [
+                {
+                    "isRegex": false,
+                    "name": "instance",
+                    "value": "server7"
+                }
+            ],
+            "startsAt": "2017-07-22T01:07:54.316475956Z",
+            "status": {
+                "state": "active"
+            },
+            "updatedAt": "2017-07-22T01:07:54.316480733Z"
+        }
+    ],
+    "status": "success"
+}

--- a/mock/0.8.0/api/v1/status
+++ b/mock/0.8.0/api/v1/status
@@ -1,0 +1,96 @@
+{
+    "data": {
+        "configJSON": {
+            "global": {
+                "hipchat_url": "https://api.hipchat.com/",
+                "opsgenie_api_host": "https://api.opsgenie.com/",
+                "pagerduty_url": "https://events.pagerduty.com/generic/2010-04-15/create_event.json",
+                "resolve_timeout": 300000000000,
+                "smtp_require_tls": true,
+                "victorops_api_url": "https://alert.victorops.com/integrations/generic/20131114/alert/"
+            },
+            "inhibit_rules": [
+                {
+                    "equal": [
+                        "alertname",
+                        "cluster",
+                        "service"
+                    ],
+                    "source_match": {
+                        "severity": "critical"
+                    },
+                    "target_match": {
+                        "severity": "warning"
+                    }
+                }
+            ],
+            "receivers": [
+                {
+                    "name": "default"
+                },
+                {
+                    "name": "by-cluster-service"
+                },
+                {
+                    "name": "by-name"
+                }
+            ],
+            "route": {
+                "group_by": [
+                    "alertname"
+                ],
+                "group_interval": 35000000000,
+                "group_wait": 15000000000,
+                "receiver": "default",
+                "repeat_interval": 3596400000000000,
+                "routes": [
+                    {
+                        "continue": true,
+                        "group_by": [
+                            "alertname",
+                            "cluster",
+                            "service"
+                        ],
+                        "match_re": {
+                            "alertname": "^(?:.*)$"
+                        },
+                        "receiver": "by-cluster-service"
+                    },
+                    {
+                        "continue": true,
+                        "group_by": [
+                            "alertname"
+                        ],
+                        "match_re": {
+                            "alertname": "^(?:.*)$"
+                        },
+                        "receiver": "by-name"
+                    }
+                ]
+            },
+            "templates": null
+        },
+        "configYAML": "global:\n  resolve_timeout: 5m\n  smtp_require_tls: true\n  pagerduty_url: https://events.pagerduty.com/generic/2010-04-15/create_event.json\n  hipchat_url: https://api.hipchat.com/\n  opsgenie_api_host: https://api.opsgenie.com/\n  victorops_api_url: https://alert.victorops.com/integrations/generic/20131114/alert/\nroute:\n  receiver: default\n  group_by:\n  - alertname\n  routes:\n  - receiver: by-cluster-service\n    group_by:\n    - alertname\n    - cluster\n    - service\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  - receiver: by-name\n    group_by:\n    - alertname\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  group_wait: 15s\n  group_interval: 35s\n  repeat_interval: 999h\ninhibit_rules:\n- source_match:\n    severity: critical\n  target_match:\n    severity: warning\n  equal:\n  - alertname\n  - cluster\n  - service\nreceivers:\n- name: default\n- name: by-cluster-service\n- name: by-name\ntemplates: []\n",
+        "meshStatus": {
+            "name": "02:42:ac:11:00:02",
+            "nickName": "eaa7828032f9",
+            "peers": [
+                {
+                    "name": "02:42:ac:11:00:02",
+                    "nickName": "eaa7828032f9",
+                    "uid": 6874768980588183501
+                }
+            ]
+        },
+        "uptime": "2017-07-22T01:07:38.96080204Z",
+        "versionInfo": {
+            "branch": "HEAD",
+            "buildDate": "20170720-14:14:06",
+            "buildUser": "root@439065dc2905",
+            "goVersion": "go1.8.3",
+            "revision": "74e7e48d24bddd2e2a80c7840af9b2de271cc74c",
+            "version": "0.8.0"
+        }
+    },
+    "status": "success"
+}

--- a/mock/Makefile
+++ b/mock/Makefile
@@ -3,7 +3,7 @@ DOCKER_IMAGE := prom/alertmanager
 DOCKER_ARGS  := --name $(DOCKER_NAME) --rm -d -p 9093:9093 -v $(CURDIR)/alertmanager.yml:/etc/alertmanager/config.yml
 
 # list of Alertmanager versions to generate mock files for
-VERSIONS := 0.4.0 0.4.1 0.4.2 0.5.0 0.5.1 0.6.0 0.6.2 0.7.0 0.7.1
+VERSIONS := 0.4.0 0.4.1 0.4.2 0.5.0 0.5.1 0.6.0 0.6.2 0.7.0 0.7.1 0.8.0
 
 %/.ok: livemock.py
 	$(eval VERSION := $(word 1, $(subst /, ,$@)))


### PR DESCRIPTION
Alertmanager 0.8.0 is out - https://github.com/prometheus/alertmanager/releases/tag/v0.8.0
Add mock data so we test against this release, fix failing tests.