### PR TITLE
Save filters usage history to local storage and provide a dropdown me…

### DIFF
--- a/assets/static/__mocks__/localStorageMock.js
+++ b/assets/static/__mocks__/localStorageMock.js
@@ -1,22 +1,21 @@
-// source: https://github.com/facebook/jest/issues/2098
+class LocalStorageMock {
 
-var localStorageMock = (function() {
-    var store = {};
+    constructor() {
+        this.store = {};
+    }
 
-    return {
-        getItem: function(key) {
-            return store[key] || null;
-        },
-        setItem: function(key, value) {
-            store[key] = value.toString();
-        },
-        clear: function() {
-            store = {};
-        }
-    };
+    getItem(key) {
+        return this.store[key] || null;
+    }
 
-})();
+    setItem(key, value) {
+        this.store[key] = value.toString();
+    }
 
-Object.defineProperty(window, "localStorage", {
-    value: localStorageMock
-});
+    clear() {
+        this.store = {};
+    }
+
+}
+
+module.exports = new LocalStorageMock();

--- a/assets/static/__mocks__/localStorageMock.js
+++ b/assets/static/__mocks__/localStorageMock.js
@@ -1,0 +1,22 @@
+// source: https://github.com/facebook/jest/issues/2098
+
+var localStorageMock = (function() {
+    var store = {};
+
+    return {
+        getItem: function(key) {
+            return store[key] || null;
+        },
+        setItem: function(key, value) {
+            store[key] = value.toString();
+        },
+        clear: function() {
+            store = {};
+        }
+    };
+
+})();
+
+Object.defineProperty(window, "localStorage", {
+    value: localStorageMock
+});

--- a/assets/static/__mocks__/templatesMock.js
+++ b/assets/static/__mocks__/templatesMock.js
@@ -9,6 +9,7 @@ function loadTemplates() {
         "modal.html",
         "silence.html",
         "summary.html",
+        "history.html",
     ];
     templateFiles.forEach(function(filename){
         var templatePath = path.join(__dirname, "../../templates/", filename);

--- a/assets/static/__snapshots__/filters.test.js.snap
+++ b/assets/static/__snapshots__/filters.test.js.snap
@@ -1,7 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`appended filtes should be present in history 1`] = `
-"<li class=\\"history-menu\\">
+"<li role=\\"separator\\" class=\\"divider\\"></li>
+  
+    
+<li class=\\"history-menu\\">
   <a class=\\"cursor-pointer history-menu-item\\">
     <span class=\\"rawFilter hidden\\">
       default
@@ -22,7 +25,7 @@ exports[`appended filtes should be present in history 2`] = `
     <span class=\\"rawFilter hidden\\">
       default
     </span>
-    <i class=\\"fa fa-circle-o transparent\\"></i>
+    <i class=\\"fa fa-search\\"></i>
     
       <span class=\\"label-list label label-info\\">
         default
@@ -35,7 +38,9 @@ exports[`appended filtes should be present in history 2`] = `
   
 
 
+  <li role=\\"separator\\" class=\\"divider\\"></li>
   
+    
 <li class=\\"history-menu\\">
   <a class=\\"cursor-pointer history-menu-item\\">
     <span class=\\"rawFilter hidden\\">
@@ -57,7 +62,7 @@ exports[`appended filtes should be present in history 3`] = `
     <span class=\\"rawFilter hidden\\">
       default,bar
     </span>
-    <i class=\\"fa fa-circle-o transparent\\"></i>
+    <i class=\\"fa fa-search\\"></i>
     
       <span class=\\"label-list label label-info\\">
         default
@@ -79,7 +84,7 @@ exports[`appended filtes should be present in history 3`] = `
     <span class=\\"rawFilter hidden\\">
       default
     </span>
-    <i class=\\"fa fa-circle-o transparent\\"></i>
+    <i class=\\"fa fa-search\\"></i>
     
       <span class=\\"label-list label label-info\\">
         default
@@ -92,7 +97,9 @@ exports[`appended filtes should be present in history 3`] = `
   
 
 
+  <li role=\\"separator\\" class=\\"divider\\"></li>
   
+    
 <li class=\\"history-menu\\">
   <a class=\\"cursor-pointer history-menu-item\\">
     <span class=\\"rawFilter hidden\\">
@@ -114,7 +121,7 @@ exports[`appended filtes should be present in history 4`] = `
     <span class=\\"rawFilter hidden\\">
       default,bar,@state=active
     </span>
-    <i class=\\"fa fa-circle-o transparent\\"></i>
+    <i class=\\"fa fa-search\\"></i>
     
       <span class=\\"label-list label label-info\\">
         default
@@ -140,7 +147,7 @@ exports[`appended filtes should be present in history 4`] = `
     <span class=\\"rawFilter hidden\\">
       default,bar
     </span>
-    <i class=\\"fa fa-circle-o transparent\\"></i>
+    <i class=\\"fa fa-search\\"></i>
     
       <span class=\\"label-list label label-info\\">
         default
@@ -162,7 +169,7 @@ exports[`appended filtes should be present in history 4`] = `
     <span class=\\"rawFilter hidden\\">
       default
     </span>
-    <i class=\\"fa fa-circle-o transparent\\"></i>
+    <i class=\\"fa fa-search\\"></i>
     
       <span class=\\"label-list label label-info\\">
         default
@@ -175,7 +182,9 @@ exports[`appended filtes should be present in history 4`] = `
   
 
 
+  <li role=\\"separator\\" class=\\"divider\\"></li>
   
+    
 <li class=\\"history-menu\\">
   <a class=\\"cursor-pointer history-menu-item\\">
     <span class=\\"rawFilter hidden\\">
@@ -197,7 +206,7 @@ exports[`appended filtes should be present in history 5`] = `
     <span class=\\"rawFilter hidden\\">
       default,bar,@state=active
     </span>
-    <i class=\\"fa fa-circle-o transparent\\"></i>
+    <i class=\\"fa fa-search\\"></i>
     
       <span class=\\"label-list label label-info\\">
         default
@@ -223,7 +232,7 @@ exports[`appended filtes should be present in history 5`] = `
     <span class=\\"rawFilter hidden\\">
       default,bar
     </span>
-    <i class=\\"fa fa-circle-o transparent\\"></i>
+    <i class=\\"fa fa-search\\"></i>
     
       <span class=\\"label-list label label-info\\">
         default
@@ -245,7 +254,7 @@ exports[`appended filtes should be present in history 5`] = `
     <span class=\\"rawFilter hidden\\">
       default
     </span>
-    <i class=\\"fa fa-circle-o transparent\\"></i>
+    <i class=\\"fa fa-search\\"></i>
     
       <span class=\\"label-list label label-info\\">
         default
@@ -258,7 +267,9 @@ exports[`appended filtes should be present in history 5`] = `
   
 
 
+  <li role=\\"separator\\" class=\\"divider\\"></li>
   
+    
 <li class=\\"history-menu\\">
   <a class=\\"cursor-pointer history-menu-item\\">
     <span class=\\"rawFilter hidden\\">
@@ -280,7 +291,7 @@ exports[`appended filtes should be present in history 6`] = `
     <span class=\\"rawFilter hidden\\">
       @state=active
     </span>
-    <i class=\\"fa fa-circle-o transparent\\"></i>
+    <i class=\\"fa fa-search\\"></i>
     
       <span class=\\"label-list label label-info\\">
         @state=active
@@ -298,7 +309,7 @@ exports[`appended filtes should be present in history 6`] = `
     <span class=\\"rawFilter hidden\\">
       default,bar,@state=active
     </span>
-    <i class=\\"fa fa-circle-o transparent\\"></i>
+    <i class=\\"fa fa-search\\"></i>
     
       <span class=\\"label-list label label-info\\">
         default
@@ -324,7 +335,7 @@ exports[`appended filtes should be present in history 6`] = `
     <span class=\\"rawFilter hidden\\">
       default,bar
     </span>
-    <i class=\\"fa fa-circle-o transparent\\"></i>
+    <i class=\\"fa fa-search\\"></i>
     
       <span class=\\"label-list label label-info\\">
         default
@@ -341,7 +352,9 @@ exports[`appended filtes should be present in history 6`] = `
   
 
 
+  <li role=\\"separator\\" class=\\"divider\\"></li>
   
+    
 <li class=\\"history-menu\\">
   <a class=\\"cursor-pointer history-menu-item\\">
     <span class=\\"rawFilter hidden\\">
@@ -358,7 +371,10 @@ exports[`appended filtes should be present in history 6`] = `
 `;
 
 exports[`default filter should be in history after setting filter to foo 1`] = `
-"<li class=\\"history-menu\\">
+"<li role=\\"separator\\" class=\\"divider\\"></li>
+  
+    
+<li class=\\"history-menu\\">
   <a class=\\"cursor-pointer history-menu-item\\">
     <span class=\\"rawFilter hidden\\">
       default

--- a/assets/static/__snapshots__/filters.test.js.snap
+++ b/assets/static/__snapshots__/filters.test.js.snap
@@ -1,0 +1,374 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`appended filtes should be present in history 1`] = `
+"<li class=\\"history-menu\\">
+  <a class=\\"cursor-pointer history-menu-item\\">
+    <span class=\\"rawFilter hidden\\">
+      default
+    </span>
+    <i class=\\"fa fa-home\\"></i>
+    
+      <span class=\\"label-list label label-info\\">
+        default
+      </span>
+    
+  </a>
+</li>"
+`;
+
+exports[`appended filtes should be present in history 2`] = `
+"<li class=\\"history-menu\\">
+  <a class=\\"cursor-pointer history-menu-item\\">
+    <span class=\\"rawFilter hidden\\">
+      default
+    </span>
+    <i class=\\"fa fa-circle-o transparent\\"></i>
+    
+      <span class=\\"label-list label label-info\\">
+        default
+      </span>
+    
+  </a>
+</li>
+
+    
+  
+
+
+  
+<li class=\\"history-menu\\">
+  <a class=\\"cursor-pointer history-menu-item\\">
+    <span class=\\"rawFilter hidden\\">
+      default
+    </span>
+    <i class=\\"fa fa-home\\"></i>
+    
+      <span class=\\"label-list label label-info\\">
+        default
+      </span>
+    
+  </a>
+</li>"
+`;
+
+exports[`appended filtes should be present in history 3`] = `
+"<li class=\\"history-menu\\">
+  <a class=\\"cursor-pointer history-menu-item\\">
+    <span class=\\"rawFilter hidden\\">
+      default,bar
+    </span>
+    <i class=\\"fa fa-circle-o transparent\\"></i>
+    
+      <span class=\\"label-list label label-info\\">
+        default
+      </span>
+    
+      <span class=\\"label-list label label-info\\">
+        bar
+      </span>
+    
+  </a>
+</li>
+
+    
+  
+    
+      
+<li class=\\"history-menu\\">
+  <a class=\\"cursor-pointer history-menu-item\\">
+    <span class=\\"rawFilter hidden\\">
+      default
+    </span>
+    <i class=\\"fa fa-circle-o transparent\\"></i>
+    
+      <span class=\\"label-list label label-info\\">
+        default
+      </span>
+    
+  </a>
+</li>
+
+    
+  
+
+
+  
+<li class=\\"history-menu\\">
+  <a class=\\"cursor-pointer history-menu-item\\">
+    <span class=\\"rawFilter hidden\\">
+      default
+    </span>
+    <i class=\\"fa fa-home\\"></i>
+    
+      <span class=\\"label-list label label-info\\">
+        default
+      </span>
+    
+  </a>
+</li>"
+`;
+
+exports[`appended filtes should be present in history 4`] = `
+"<li class=\\"history-menu\\">
+  <a class=\\"cursor-pointer history-menu-item\\">
+    <span class=\\"rawFilter hidden\\">
+      default,bar,@state=active
+    </span>
+    <i class=\\"fa fa-circle-o transparent\\"></i>
+    
+      <span class=\\"label-list label label-info\\">
+        default
+      </span>
+    
+      <span class=\\"label-list label label-info\\">
+        bar
+      </span>
+    
+      <span class=\\"label-list label label-info\\">
+        @state=active
+      </span>
+    
+  </a>
+</li>
+
+    
+  
+    
+      
+<li class=\\"history-menu\\">
+  <a class=\\"cursor-pointer history-menu-item\\">
+    <span class=\\"rawFilter hidden\\">
+      default,bar
+    </span>
+    <i class=\\"fa fa-circle-o transparent\\"></i>
+    
+      <span class=\\"label-list label label-info\\">
+        default
+      </span>
+    
+      <span class=\\"label-list label label-info\\">
+        bar
+      </span>
+    
+  </a>
+</li>
+
+    
+  
+    
+      
+<li class=\\"history-menu\\">
+  <a class=\\"cursor-pointer history-menu-item\\">
+    <span class=\\"rawFilter hidden\\">
+      default
+    </span>
+    <i class=\\"fa fa-circle-o transparent\\"></i>
+    
+      <span class=\\"label-list label label-info\\">
+        default
+      </span>
+    
+  </a>
+</li>
+
+    
+  
+
+
+  
+<li class=\\"history-menu\\">
+  <a class=\\"cursor-pointer history-menu-item\\">
+    <span class=\\"rawFilter hidden\\">
+      default
+    </span>
+    <i class=\\"fa fa-home\\"></i>
+    
+      <span class=\\"label-list label label-info\\">
+        default
+      </span>
+    
+  </a>
+</li>"
+`;
+
+exports[`appended filtes should be present in history 5`] = `
+"<li class=\\"history-menu\\">
+  <a class=\\"cursor-pointer history-menu-item\\">
+    <span class=\\"rawFilter hidden\\">
+      default,bar,@state=active
+    </span>
+    <i class=\\"fa fa-circle-o transparent\\"></i>
+    
+      <span class=\\"label-list label label-info\\">
+        default
+      </span>
+    
+      <span class=\\"label-list label label-info\\">
+        bar
+      </span>
+    
+      <span class=\\"label-list label label-info\\">
+        @state=active
+      </span>
+    
+  </a>
+</li>
+
+    
+  
+    
+      
+<li class=\\"history-menu\\">
+  <a class=\\"cursor-pointer history-menu-item\\">
+    <span class=\\"rawFilter hidden\\">
+      default,bar
+    </span>
+    <i class=\\"fa fa-circle-o transparent\\"></i>
+    
+      <span class=\\"label-list label label-info\\">
+        default
+      </span>
+    
+      <span class=\\"label-list label label-info\\">
+        bar
+      </span>
+    
+  </a>
+</li>
+
+    
+  
+    
+      
+<li class=\\"history-menu\\">
+  <a class=\\"cursor-pointer history-menu-item\\">
+    <span class=\\"rawFilter hidden\\">
+      default
+    </span>
+    <i class=\\"fa fa-circle-o transparent\\"></i>
+    
+      <span class=\\"label-list label label-info\\">
+        default
+      </span>
+    
+  </a>
+</li>
+
+    
+  
+
+
+  
+<li class=\\"history-menu\\">
+  <a class=\\"cursor-pointer history-menu-item\\">
+    <span class=\\"rawFilter hidden\\">
+      default
+    </span>
+    <i class=\\"fa fa-home\\"></i>
+    
+      <span class=\\"label-list label label-info\\">
+        default
+      </span>
+    
+  </a>
+</li>"
+`;
+
+exports[`appended filtes should be present in history 6`] = `
+"<li class=\\"history-menu\\">
+  <a class=\\"cursor-pointer history-menu-item\\">
+    <span class=\\"rawFilter hidden\\">
+      @state=active
+    </span>
+    <i class=\\"fa fa-circle-o transparent\\"></i>
+    
+      <span class=\\"label-list label label-info\\">
+        @state=active
+      </span>
+    
+  </a>
+</li>
+
+    
+  
+    
+      
+<li class=\\"history-menu\\">
+  <a class=\\"cursor-pointer history-menu-item\\">
+    <span class=\\"rawFilter hidden\\">
+      default,bar,@state=active
+    </span>
+    <i class=\\"fa fa-circle-o transparent\\"></i>
+    
+      <span class=\\"label-list label label-info\\">
+        default
+      </span>
+    
+      <span class=\\"label-list label label-info\\">
+        bar
+      </span>
+    
+      <span class=\\"label-list label label-info\\">
+        @state=active
+      </span>
+    
+  </a>
+</li>
+
+    
+  
+    
+      
+<li class=\\"history-menu\\">
+  <a class=\\"cursor-pointer history-menu-item\\">
+    <span class=\\"rawFilter hidden\\">
+      default,bar
+    </span>
+    <i class=\\"fa fa-circle-o transparent\\"></i>
+    
+      <span class=\\"label-list label label-info\\">
+        default
+      </span>
+    
+      <span class=\\"label-list label label-info\\">
+        bar
+      </span>
+    
+  </a>
+</li>
+
+    
+  
+
+
+  
+<li class=\\"history-menu\\">
+  <a class=\\"cursor-pointer history-menu-item\\">
+    <span class=\\"rawFilter hidden\\">
+      default
+    </span>
+    <i class=\\"fa fa-home\\"></i>
+    
+      <span class=\\"label-list label label-info\\">
+        default
+      </span>
+    
+  </a>
+</li>"
+`;
+
+exports[`default filter should be in history after setting filter to foo 1`] = `
+"<li class=\\"history-menu\\">
+  <a class=\\"cursor-pointer history-menu-item\\">
+    <span class=\\"rawFilter hidden\\">
+      default
+    </span>
+    <i class=\\"fa fa-home\\"></i>
+    
+      <span class=\\"label-list label label-info\\">
+        default
+      </span>
+    
+  </a>
+</li>"
+`;

--- a/assets/static/base.css
+++ b/assets/static/base.css
@@ -141,7 +141,7 @@ span.label-ts-span {
 
 /* make filter input take all the space it can */
 div.filterbar {
-    width: 950px;
+    width: 905px;
 }
 div.filterbar > .input-group-addon.input-sm {
     width: 10px;
@@ -186,12 +186,14 @@ div.bootstrap-tagsinput > .twitter-typeahead > input.tt-input {
 
 /* menus uses links with icons instead of buttons, fix focus color
    so the link doesn't stay colored after clicking */
+#history:focus,
 #help:focus,
 #settings:focus,
 #refresh:focus {
     color: #fff;
 }
 
+#history:hover,
 #help:hover,
 #settings:hover,
 #refresh:hover {
@@ -497,4 +499,15 @@ a[aria-expanded=false] .fa-chevron-down {
 
 .alert-static-elements {
   margin-bottom: 4px;
+}
+
+.transparent {
+  opacity: 0;
+}
+
+li.history-menu > a.history-menu-item {
+  padding-left: 10px;
+  padding-right: 4px;
+  padding-top: 2px;
+  padding-bottom: 6px;
 }

--- a/assets/static/base.css
+++ b/assets/static/base.css
@@ -501,10 +501,6 @@ a[aria-expanded=false] .fa-chevron-down {
   margin-bottom: 4px;
 }
 
-.transparent {
-  opacity: 0;
-}
-
 li.history-menu > a.history-menu-item {
   padding-left: 10px;
   padding-right: 4px;

--- a/assets/static/filters.js
+++ b/assets/static/filters.js
@@ -21,6 +21,7 @@ var selectors = {
     historyMenu: "#historyMenu"
 };
 var appendsEnabled = true;
+var historyStorage;
 const historyKey = "filterHistory";
 
 function addBadge(text) {
@@ -69,13 +70,11 @@ function setPause() {
 }
 
 function renderHistory() {
-    const storage = window.localStorage;
-
     var historicFilters = [];
 
     const currentFilterText = getFilters().join(",");
 
-    const history = storage.getItem(historyKey);
+    const history = historyStorage.getItem(historyKey);
     if (history) {
         historicFilters = history.split("\n");
     }
@@ -93,14 +92,12 @@ function appendFilterToHistory(text) {
     // require non empty text and enabled appends
     if (!text || !appendsEnabled) return false;
 
-    const storage = window.localStorage;
-
     // final filter list we'll save to storage
     var filterList = [ text ];
 
     // get current history list from storage and append it to our final list
     // of filters, but avoid duplicates
-    const history = storage.getItem(historyKey);
+    const history = historyStorage.getItem(historyKey);
     if (history) {
         const historyArr = history.split("\n");
         for (var i = 0; i < historyArr.length; i++) {
@@ -114,7 +111,7 @@ function appendFilterToHistory(text) {
     // truncate the history to up to 11 elements
     filterList = filterList.slice(0, 11);
 
-    storage.setItem(historyKey, filterList.join("\n"));
+    historyStorage.setItem(historyKey, filterList.join("\n"));
 }
 
 function setFilters() {
@@ -131,7 +128,8 @@ function setFilters() {
     unsee.triggerReload();
 }
 
-function init() {
+function init(historyStore) {
+    historyStorage = historyStore;
     var initialFilter;
 
     if ($(selectors.filter).data("default-used") == "false" || $(selectors.filter).data("default-used") === false) {

--- a/assets/static/filters.js
+++ b/assets/static/filters.js
@@ -110,7 +110,7 @@ function appendFilterToHistory(text) {
     }
 
     // truncate the history to up to 11 elements
-    const filterListTrunc = Array.from(filterList).slice(0, 11);
+    const filterListTrunc = Array.from(filterList).slice(0, 10);
 
     historyStorage.setItem(historyKey, filterListTrunc.join("\n"));
 }

--- a/assets/static/filters.js
+++ b/assets/static/filters.js
@@ -56,6 +56,10 @@ function addFilter(text) {
     $(selectors.filter).tagsinput("add", text);
 }
 
+function clearFilters() {
+    $(selectors.filter).tagsinput("removeAll");
+}
+
 function setUpdating() {
     // visual hint that alerts are reloaded due to filter change
     $(selectors.icon).removeClass("fa-search fa-pause").addClass("fa-circle-o-notch fa-spin");
@@ -217,6 +221,7 @@ function init(historyStore) {
 
 exports.init = init;
 exports.addFilter = addFilter;
+exports.clearFilters = clearFilters;
 exports.setFilters = setFilters;
 exports.getFilters = getFilters;
 exports.addBadge = addBadge;

--- a/assets/static/filters.js
+++ b/assets/static/filters.js
@@ -13,11 +13,15 @@ require("./bootstrap-tagsinput.less");
 const autocomplete = require("./autocomplete");
 const unsee = require("./unsee");
 const querystring = require("./querystring");
+const templates = require("./templates");
 
 var selectors = {
     filter: "#filter",
-    icon: "#filter-icon"
+    icon: "#filter-icon",
+    historyMenu: "#historyMenu"
 };
+var appendsEnabled = true;
+const historyKey = "filterHistory";
 
 function addBadge(text) {
     $.each($("span.tag"), function(i, tag) {
@@ -64,11 +68,64 @@ function setPause() {
     $(selectors.icon).removeClass("fa-circle-o-notch fa-spin fa-search").addClass("fa-pause");
 }
 
+function renderHistory() {
+    const storage = window.localStorage;
+
+    var historicFilters = [];
+
+    const currentFilterText = getFilters().join(",");
+
+    const history = storage.getItem(historyKey);
+    if (history) {
+        historicFilters = history.split("\n");
+    }
+
+    var historyMenuHTML = templates.renderTemplate("historyMenu", {
+        activeFilter: currentFilterText,
+        defaultFilter: $(selectors.filter).data("default-filter"),
+        savedFilter: Cookies.get("defaultFilter.v2"),
+        filters: historicFilters
+    });
+    $(selectors.historyMenu).html(historyMenuHTML);
+}
+
+function appendFilterToHistory(text) {
+    // require non empty text and enabled appends
+    if (!text || !appendsEnabled) return false;
+
+    const storage = window.localStorage;
+
+    // final filter list we'll save to storage
+    var filterList = [ text ];
+
+    // get current history list from storage and append it to our final list
+    // of filters, but avoid duplicates
+    const history = storage.getItem(historyKey);
+    if (history) {
+        const historyArr = history.split("\n");
+        for (var i = 0; i < historyArr.length; i++) {
+            var h = historyArr[i];
+            if (filterList.indexOf(h) < 0) {
+                filterList.push(h);
+            }
+        }
+    }
+
+    // truncate the history to up to 11 elements
+    filterList = filterList.slice(0, 11);
+
+    storage.setItem(historyKey, filterList.join("\n"));
+}
+
 function setFilters() {
     setUpdating();
 
     // update location so it's easy to share it
     querystring.update("q", getFilters().join(","));
+
+    // append filter to the history and render it
+    appendFilterToHistory(getFilters().join(","));
+    renderHistory();
 
     // reload alerts
     unsee.triggerReload();
@@ -139,6 +196,26 @@ function init() {
     $(".filterbar").on("resize", function(){
         // hack for fixing padding since input can grow and change height
         $("body").css("padding-top", $(".navbar").height());
+    });
+
+    renderHistory();
+    $(selectors.historyMenu).on("click", "a.history-menu-item", function(event) {
+        var elem = $(event.target).parents("li.history-menu");
+        const historyArr = elem.find(".rawFilter").text().trim().split(",");
+        // we need to add filters one by one, this would reload alerts on every
+        // add() so let's pause reloads and resume once we're done with updating
+        // filters
+        unsee.pause();
+        // disable history appends as it would record each new filter in the
+        // history
+        appendsEnabled = false;
+        $(selectors.filter).tagsinput("removeAll");
+        for (var i = 0; i < historyArr.length; i++) {
+            $(selectors.filter).tagsinput("add", historyArr[i]);
+        }
+        // enable everything again
+        appendsEnabled = true;
+        unsee.resume();
     });
 
 }

--- a/assets/static/filters.js
+++ b/assets/static/filters.js
@@ -93,7 +93,7 @@ function appendFilterToHistory(text) {
     if (!text || !appendsEnabled) return false;
 
     // final filter list we'll save to storage
-    var filterList = [ text ];
+    var filterList = new Set([ text ]);
 
     // get current history list from storage and append it to our final list
     // of filters, but avoid duplicates
@@ -101,17 +101,14 @@ function appendFilterToHistory(text) {
     if (history) {
         const historyArr = history.split("\n");
         for (var i = 0; i < historyArr.length; i++) {
-            var h = historyArr[i];
-            if (filterList.indexOf(h) < 0) {
-                filterList.push(h);
-            }
+            filterList.add(historyArr[i]);
         }
     }
 
     // truncate the history to up to 11 elements
-    filterList = filterList.slice(0, 11);
+    const filterListTrunc = Array.from(filterList).slice(0, 11);
 
-    historyStorage.setItem(historyKey, filterList.join("\n"));
+    historyStorage.setItem(historyKey, filterListTrunc.join("\n"));
 }
 
 function setFilters() {

--- a/assets/static/filters.js
+++ b/assets/static/filters.js
@@ -229,3 +229,4 @@ exports.reloadBadges = reloadBadges;
 exports.updateDone = updateDone;
 exports.setUpdating = setUpdating;
 exports.setPause = setPause;
+exports.renderHistory = renderHistory;

--- a/assets/static/filters.js
+++ b/assets/static/filters.js
@@ -56,6 +56,23 @@ function addFilter(text) {
     $(selectors.filter).tagsinput("add", text);
 }
 
+function applyFilterList(filterList) {
+    // we need to add filters one by one, this would reload alerts on every
+    // add() so let's pause reloads and resume once we're done with updating
+    // filters
+    unsee.pause();
+    // disable history appends as it would record each new filter in the
+    // history
+    appendsEnabled = false;
+    $(selectors.filter).tagsinput("removeAll");
+    for (var i = 0; i < filterList.length; i++) {
+        $(selectors.filter).tagsinput("add", filterList[i]);
+    }
+    // enable everything again
+    appendsEnabled = true;
+    unsee.resume();
+}
+
 function clearFilters() {
     $(selectors.filter).tagsinput("removeAll");
 }
@@ -200,21 +217,8 @@ function init(historyStore) {
     renderHistory();
     $(selectors.historyMenu).on("click", "a.history-menu-item", function(event) {
         var elem = $(event.target).parents("li.history-menu");
-        const historyArr = elem.find(".rawFilter").text().trim().split(",");
-        // we need to add filters one by one, this would reload alerts on every
-        // add() so let's pause reloads and resume once we're done with updating
-        // filters
-        unsee.pause();
-        // disable history appends as it would record each new filter in the
-        // history
-        appendsEnabled = false;
-        $(selectors.filter).tagsinput("removeAll");
-        for (var i = 0; i < historyArr.length; i++) {
-            $(selectors.filter).tagsinput("add", historyArr[i]);
-        }
-        // enable everything again
-        appendsEnabled = true;
-        unsee.resume();
+        const filtersList = elem.find(".rawFilter").text().trim().split(",");
+        applyFilterList(filtersList);
     });
 
 }

--- a/assets/static/filters.test.js
+++ b/assets/static/filters.test.js
@@ -30,10 +30,10 @@ test("default filter should be in history after setting filter to foo", () => {
     filters.setFilters();
     filters.renderHistory();
 
-    var elems = $("#historyMenu").find(".rawFilter");
-    // foo is active so should only get default
-    expect(elems.length).toBe(1);
-    expect($(elems[0]).text().trim()).toBe("default");
+    // use snapshot to check that generated HTML is what we expect
+    const historyMenu = $("#historyMenu").html().trim();
+    expect(historyMenu).toMatchSnapshot();
+
     // we set foo, so that what should be in history
     expect(LocalStorageMock.getItem("filterHistory")).toBe("foo");
 });
@@ -62,24 +62,19 @@ test("appended filtes should be present in history", () => {
     filters.setFilters();
     filters.renderHistory();
 
-    // default is used, expect single history entry
-    var elems = $("#historyMenu").find(".rawFilter");
-    expect(elems.length).toBe(1);
-    // default is used but default is always rendered so should be there
-    expect($(elems[0]).text().trim()).toBe("default");
+    // we only used default, so there should be a single (default) entry
+    let historyMenu = $("#historyMenu").html().trim();
+    expect(historyMenu).toMatchSnapshot();
     // and that's what history should have
     expect(LocalStorageMock.getItem("filterHistory")).toBe("default");
 
     // now we append more filters, so q=default becomes q=default,bar
     filters.addFilter("bar");
     filters.setFilters();
-
-    elems = $("#historyMenu").find(".rawFilter");
-    expect(elems.length).toBe(2);
-    // default will be repeated because it's both: last filter and the defult
-    // that's always rendered
-    expect($(elems[0]).text().trim()).toBe("default");
-    expect($(elems[1]).text().trim()).toBe("default");
+    // now we got non-default filter as active, so we should have 2 entries
+    // both for default (as recent and as global default)
+    historyMenu = $("#historyMenu").html().trim();
+    expect(historyMenu).toMatchSnapshot();
     expect(
         LocalStorageMock.getItem("filterHistory").split("\n")
     ).toMatchObject(
@@ -89,17 +84,50 @@ test("appended filtes should be present in history", () => {
     // append another filter, so we now have: q=default,bar,@state=active
     filters.addFilter("@state=active");
     filters.setFilters();
-
-    elems = $("#historyMenu").find(".rawFilter");
-    expect(elems.length).toBe(3);
-    // default will be repeated because it's both: last filter and the defult
-    // that's always rendered
-    expect($(elems[0]).text().trim()).toBe("default,bar");
-    expect($(elems[1]).text().trim()).toBe("default");
-    expect($(elems[1]).text().trim()).toBe("default");
+    // now we should have 3 entries, 2x default + default,bar
+    historyMenu = $("#historyMenu").html().trim();
+    expect(historyMenu).toMatchSnapshot();
     expect(
         LocalStorageMock.getItem("filterHistory").split("\n")
     ).toMatchObject(
         [ "default,bar,@state=active", "default,bar", "default" ]
+    );
+
+    // clear filters, so now we have: q=
+    filters.clearFilters();
+    filters.setFilters();
+    // now we should have 4 entries, 2x default + default,bar + default,bar,@state=active
+    historyMenu = $("#historyMenu").html().trim();
+    expect(historyMenu).toMatchSnapshot();
+    expect(
+        LocalStorageMock.getItem("filterHistory").split("\n")
+    ).toMatchObject(
+        [ "default,bar,@state=active", "default,bar", "default" ]
+    );
+
+    // now add a filter back, so now we have: q=@state=active
+    filters.addFilter("@state=active");
+    filters.setFilters();
+    // we should have same filters as before
+    historyMenu = $("#historyMenu").html().trim();
+    expect(historyMenu).toMatchSnapshot();
+    expect(
+        LocalStorageMock.getItem("filterHistory").split("\n")
+    ).toMatchObject(
+        [ "@state=active", "default,bar,@state=active", "default,bar", "default" ]
+    );
+
+    // as a last test add default back to have @state=active rendered
+    filters.clearFilters();
+    filters.addFilter("default");
+    filters.setFilters();
+    // we should have same filters as before
+    historyMenu = $("#historyMenu").html().trim();
+    expect(historyMenu).toMatchSnapshot();
+    // default should move from the bottom to to top of the list
+    expect(
+        LocalStorageMock.getItem("filterHistory").split("\n")
+    ).toMatchObject(
+        [ "default", "@state=active", "default,bar,@state=active", "default,bar" ]
     );
 });

--- a/assets/static/filters.test.js
+++ b/assets/static/filters.test.js
@@ -1,5 +1,5 @@
 const $ = window.jQuery = require("jquery");
-require("./__mocks__/localStorageMock");
+const LocalStorageMock = require("./__mocks__/localStorageMock");
 
 test("filters addBadge()", () => {
     const filters = require("./filters");
@@ -7,7 +7,7 @@ test("filters addBadge()", () => {
 });
 
 test("default filter should be in history after setting filter to foo", () => {
-    localStorage.clear();
+    LocalStorageMock.clear();
     document.body.innerHTML =
         "<div class='input-group filterbar'>" +
         "  <div class='input-group-addon input-sm'>" +
@@ -26,7 +26,7 @@ test("default filter should be in history after setting filter to foo", () => {
     const filters = require("./filters");
 
     autocomplete.init();
-    filters.init();
+    filters.init(LocalStorageMock);
     filters.setFilters();
     filters.renderHistory();
 
@@ -35,11 +35,11 @@ test("default filter should be in history after setting filter to foo", () => {
     expect(elems.length).toBe(1);
     expect($(elems[0]).text().trim()).toBe("default");
     // we set foo, so that what should be in history
-    expect(localStorage.getItem("filterHistory")).toBe("foo");
+    expect(LocalStorageMock.getItem("filterHistory")).toBe("foo");
 });
 
 test("appended filtes should be present in history", () => {
-    localStorage.clear();
+    LocalStorageMock.clear();
     document.body.innerHTML =
         "<div class='input-group filterbar'>" +
         "  <div class='input-group-addon input-sm'>" +
@@ -58,7 +58,7 @@ test("appended filtes should be present in history", () => {
     const filters = require("./filters");
 
     autocomplete.init();
-    filters.init();
+    filters.init(LocalStorageMock);
     filters.setFilters();
     filters.renderHistory();
 
@@ -68,7 +68,7 @@ test("appended filtes should be present in history", () => {
     // default is used but default is always rendered so should be there
     expect($(elems[0]).text().trim()).toBe("default");
     // and that's what history should have
-    expect(localStorage.getItem("filterHistory")).toBe("default");
+    expect(LocalStorageMock.getItem("filterHistory")).toBe("default");
 
     // now we append more filters, so q=default becomes q=default,bar
     filters.addFilter("bar");
@@ -81,7 +81,7 @@ test("appended filtes should be present in history", () => {
     expect($(elems[0]).text().trim()).toBe("default");
     expect($(elems[1]).text().trim()).toBe("default");
     expect(
-        localStorage.getItem("filterHistory").split("\n")
+        LocalStorageMock.getItem("filterHistory").split("\n")
     ).toMatchObject(
         [ "default,bar", "default" ]
     );
@@ -98,7 +98,7 @@ test("appended filtes should be present in history", () => {
     expect($(elems[1]).text().trim()).toBe("default");
     expect($(elems[1]).text().trim()).toBe("default");
     expect(
-        localStorage.getItem("filterHistory").split("\n")
+        LocalStorageMock.getItem("filterHistory").split("\n")
     ).toMatchObject(
         [ "default,bar,@state=active", "default,bar", "default" ]
     );

--- a/assets/static/filters.test.js
+++ b/assets/static/filters.test.js
@@ -1,7 +1,105 @@
+const $ = window.jQuery = require("jquery");
+require("./__mocks__/localStorageMock");
+
 test("filters addBadge()", () => {
-    // mock data attr with default filter
-    //document.body.innerHTML = "<div id='filter' data-default-filter='foo=bar'></div>";
-    window.jQuery = require("jquery");
     const filters = require("./filters");
     filters.addBadge("foo=bar");
+});
+
+test("default filter should be in history after setting filter to foo", () => {
+    localStorage.clear();
+    document.body.innerHTML =
+        "<div class='input-group filterbar'>" +
+        "  <div class='input-group-addon input-sm'>" +
+        "    <i class='fa fa-search' id='filter-icon'></i>" +
+        "  </div>" +
+        "  <input id='filter' type='text' value='foo' data-default-used='false' data-default-filter='default'>" +
+        "</div>" +
+        "<div id='historyMenu'></div>";
+
+    const templatesMock = require("./__mocks__/templatesMock");
+    document.body.innerHTML += templatesMock.loadTemplates();
+    const templates = require("./templates");
+    templates.init();
+
+    const autocomplete = require("./autocomplete");
+    const filters = require("./filters");
+
+    autocomplete.init();
+    filters.init();
+    filters.setFilters();
+    filters.renderHistory();
+
+    var elems = $("#historyMenu").find(".rawFilter");
+    // foo is active so should only get default
+    expect(elems.length).toBe(1);
+    expect($(elems[0]).text().trim()).toBe("default");
+    // we set foo, so that what should be in history
+    expect(localStorage.getItem("filterHistory")).toBe("foo");
+});
+
+test("appended filtes should be present in history", () => {
+    localStorage.clear();
+    document.body.innerHTML =
+        "<div class='input-group filterbar'>" +
+        "  <div class='input-group-addon input-sm'>" +
+        "    <i class='fa fa-search' id='filter-icon'></i>" +
+        "  </div>" +
+        "  <input id='filter' type='text' value='default' data-default-used='true' data-default-filter='default'>" +
+        "</div>" +
+        "<div id='historyMenu'></div>";
+
+    const templatesMock = require("./__mocks__/templatesMock");
+    document.body.innerHTML += templatesMock.loadTemplates();
+    const templates = require("./templates");
+    templates.init();
+
+    const autocomplete = require("./autocomplete");
+    const filters = require("./filters");
+
+    autocomplete.init();
+    filters.init();
+    filters.setFilters();
+    filters.renderHistory();
+
+    // default is used, expect single history entry
+    var elems = $("#historyMenu").find(".rawFilter");
+    expect(elems.length).toBe(1);
+    // default is used but default is always rendered so should be there
+    expect($(elems[0]).text().trim()).toBe("default");
+    // and that's what history should have
+    expect(localStorage.getItem("filterHistory")).toBe("default");
+
+    // now we append more filters, so q=default becomes q=default,bar
+    filters.addFilter("bar");
+    filters.setFilters();
+
+    elems = $("#historyMenu").find(".rawFilter");
+    expect(elems.length).toBe(2);
+    // default will be repeated because it's both: last filter and the defult
+    // that's always rendered
+    expect($(elems[0]).text().trim()).toBe("default");
+    expect($(elems[1]).text().trim()).toBe("default");
+    expect(
+        localStorage.getItem("filterHistory").split("\n")
+    ).toMatchObject(
+        [ "default,bar", "default" ]
+    );
+
+    // append another filter, so we now have: q=default,bar,@state=active
+    filters.addFilter("@state=active");
+    filters.setFilters();
+
+    elems = $("#historyMenu").find(".rawFilter");
+    expect(elems.length).toBe(3);
+    // default will be repeated because it's both: last filter and the defult
+    // that's always rendered
+    expect($(elems[0]).text().trim()).toBe("default,bar");
+    expect($(elems[1]).text().trim()).toBe("default");
+    expect($(elems[1]).text().trim()).toBe("default");
+    expect(
+        localStorage.getItem("filterHistory").split("\n")
+    ).toMatchObject(
+        [ "default,bar,@state=active", "default,bar", "default" ]
+    );
 });

--- a/assets/static/templates.js
+++ b/assets/static/templates.js
@@ -45,7 +45,11 @@ var templates = {},
         alertGroupLabels: "#alert-group-labels",
         alertGroupElements: "#alert-group-elements",
         alertGroupSilence: "#alert-group-silence",
-        alertGroupLabelMap: "#alert-group-label-map"
+        alertGroupLabelMap: "#alert-group-label-map",
+
+        // history dropdown
+        historyMenu: "#history-menu",
+        historyMenuItem: "#history-menu-item"
     };
 
 function getConfig() {

--- a/assets/static/unsee.js
+++ b/assets/static/unsee.js
@@ -304,7 +304,7 @@ function setupPageVisibilityHandler() {
     }
 }
 
-function init() {
+function init(localStore) {
     progress.init();
 
     config.init({
@@ -318,7 +318,7 @@ function init() {
     summary.init();
     grid.init();
     autocomplete.init();
-    filters.init();
+    filters.init(localStore);
     watchdog.init(30, 60*15); // set watchdog to 15 minutes
 
     $(selectors.refreshButton).click(function() {
@@ -331,7 +331,7 @@ function init() {
     setupPageVisibilityHandler();
 }
 
-function onReady() {
+function onReady(localStore) {
     // wrap all inits so we can handle errors
     try {
         // init all elements using bootstrapSwitch
@@ -347,7 +347,7 @@ function onReady() {
         ui.setupModal();
         silence.setupSilenceForm();
         unsilence.init();
-        init();
+        init(localStore);
 
         // delay initial alert load to allow browser finish rendering
         setTimeout(function() {
@@ -381,4 +381,6 @@ exports.flash = flash;
 exports.parseAJAXError = parseAJAXError;
 exports.onReady = onReady;
 
-$(document).ready(onReady);
+$(document).ready(function() {
+    onReady(window.localStorage);
+});

--- a/assets/static/unsee.test.js
+++ b/assets/static/unsee.test.js
@@ -1,6 +1,7 @@
 const $ = require("jquery");
 const templatesMock = require("./__mocks__/templatesMock");
 const alertsMock = require("./__mocks__/alertsMock");
+require("./__mocks__/localStorageMock");
 
 jest.useFakeTimers();
 

--- a/assets/static/unsee.test.js
+++ b/assets/static/unsee.test.js
@@ -1,7 +1,7 @@
 const $ = require("jquery");
 const templatesMock = require("./__mocks__/templatesMock");
 const alertsMock = require("./__mocks__/alertsMock");
-require("./__mocks__/localStorageMock");
+const LocalStorageMock = require("./__mocks__/localStorageMock");
 
 jest.useFakeTimers();
 
@@ -51,7 +51,7 @@ if (alertsServer) {
         require("bootstrap/js/popover.js");
         alertsServer.start();
 
-        unsee.onReady();
+        unsee.onReady(LocalStorageMock);
         unsee.triggerReload();
         jest.runOnlyPendingTimers();
         // we should have 2 alerts

--- a/assets/templates/history.html
+++ b/assets/templates/history.html
@@ -6,11 +6,9 @@
     <% } %>
   <% }) %>
 <% } %>
-
 <% if (defaultFilter) { %>
   <%= renderTemplate("historyMenuItem", {filter: defaultFilter, icon: "fa fa-home"}) %>
 <% } %>
-
 <% if (savedFilter) { %>
   <%= renderTemplate("historyMenuItem", {filter: savedFilter, icon: "fa fa-floppy-o"}) %>
 <% } %>

--- a/assets/templates/history.html
+++ b/assets/templates/history.html
@@ -2,15 +2,18 @@
 <% if (filters.length) { %>
   <% _.each(filters, function(filter) { %>
     <% if (filter !== activeFilter) { %>
-      <%= renderTemplate("historyMenuItem", {filter: filter, icon: "fa fa-circle-o transparent"}) %>
+      <%= renderTemplate("historyMenuItem", {filter: filter, icon: "fa fa-search"}) %>
     <% } %>
   <% }) %>
 <% } %>
-<% if (defaultFilter) { %>
-  <%= renderTemplate("historyMenuItem", {filter: defaultFilter, icon: "fa fa-home"}) %>
-<% } %>
-<% if (savedFilter) { %>
-  <%= renderTemplate("historyMenuItem", {filter: savedFilter, icon: "fa fa-floppy-o"}) %>
+<% if (defaultFilter || savedFilter) { %>
+  <li role="separator" class="divider"></li>
+  <% if (defaultFilter) { %>
+    <%= renderTemplate("historyMenuItem", {filter: defaultFilter, icon: "fa fa-home"}) %>
+  <% } %>
+  <% if (savedFilter) { %>
+    <%= renderTemplate("historyMenuItem", {filter: savedFilter, icon: "fa fa-floppy-o"}) %>
+  <% } %>
 <% } %>
 </script>
 

--- a/assets/templates/history.html
+++ b/assets/templates/history.html
@@ -1,0 +1,33 @@
+<script type="application/json" id="history-menu">
+<% if (filters.length) { %>
+  <% _.each(filters, function(filter) { %>
+    <% if (filter !== activeFilter) { %>
+      <%= renderTemplate("historyMenuItem", {filter: filter, icon: "fa fa-circle-o transparent"}) %>
+    <% } %>
+  <% }) %>
+<% } %>
+
+<% if (defaultFilter) { %>
+  <%= renderTemplate("historyMenuItem", {filter: defaultFilter, icon: "fa fa-home"}) %>
+<% } %>
+
+<% if (savedFilter) { %>
+  <%= renderTemplate("historyMenuItem", {filter: savedFilter, icon: "fa fa-floppy-o"}) %>
+<% } %>
+</script>
+
+<script type="application/json" id="history-menu-item">
+<li class="history-menu">
+  <a class="cursor-pointer history-menu-item">
+    <span class="rawFilter hidden">
+      <%- filter %>
+    </span>
+    <i class="<%- icon %>"></i>
+    <% _.each(filter.split(","), function(filterItem) { %>
+      <span class="label-list label label-info">
+        <%- filterItem %>
+      </span>
+    <% }) %>
+  </a>
+</li>
+</script>

--- a/assets/templates/index.html
+++ b/assets/templates/index.html
@@ -47,6 +47,13 @@
                     </div>
                 </form>
                 <ul class="nav navbar-nav navbar-right">
+                    <li class="dropdown">
+                      <a href="#" id="history" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"
+                          title="Filter history" data-toggle="tooltip" data-placement="auto">
+                          <i id="historyList" class="fa fa-history"></i>
+                      </a>
+                      <ul class="dropdown-menu" id="historyMenu"></ul>
+                    </li>
                     <li>
                         <a href="{{ .WebPrefix }}help" id="help" role="button" title="Filter documentation" data-toggle="tooltip" data-placement="auto">
                             <i class="fa fa-question-circle"></i>
@@ -177,3 +184,4 @@
 {{ template "templates/errors.html" }}
 {{ template "templates/modal.html" }}
 {{ template "templates/silence.html" }}
+{{ template "templates/history.html" }}


### PR DESCRIPTION
…nu to access it

This allows to quickly select recently used filters from a dropdown. It also shows default (configured by unsee admin) filter and the saved one (saved by the user to a cookie)

<img width="1079" alt="screen shot 2017-08-13 at 10 37 46" src="https://user-images.githubusercontent.com/114288/29251950-82f1bbbc-8013-11e7-8788-25a58888798e.png">

