### PR TITLE
Automatically disable webpack production mode when NODE_ENV=test is set

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,10 @@ Same applies to HTML template files, please rebuild bindata_assetfs.go before
 commit. Note that Makefile targets are setup to run it automatically if changes
 are detected, so it's usually not needed for development.
 
+During development you can set `NODE_ENV=test` before running any make targets,
+this will prevent webpack from using expensive optimizations only needed when
+generating production assets.
+
 ## Running
 
 To build and start `unsee` from local branch see `Running` section of the

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ endif
 	touch $@
 
 bindata_assetfs.go: .build/deps.ok .build/bindata_assetfs.$(GO_BINDATA_MODE) $(ASSET_SOURCES) webpack.config.js .build/vendor.ok
-	$(CURDIR)/node_modules/.bin/webpack -p
+	$(CURDIR)/node_modules/.bin/webpack
 	go-bindata-assetfs $(GO_BINDATA_FLAGS) -prefix assets -nometadata assets/templates/... assets/static/dist/...
 
 $(NAME): .build/deps.ok .build/vendor.ok bindata_assetfs.go $(SOURCES)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const path = require("path");
 const fs = require("fs");
 const CleanWebpackPlugin = require("clean-webpack-plugin");
 
-const config = {
+var config = {
     cache: true,
     context: path.resolve(__dirname, "assets/static"),
     entry: {
@@ -104,6 +104,21 @@ const config = {
             }
         ]
     },
+}
+
+// check what NODE_ENV is set, if it's empty we assume production
+const isDev = (process.env.NODE_ENV === "test");
+
+// enable production only plugins
+if (!isDev) {
+    config.plugins.push(new webpack.optimize.UglifyJsPlugin());
+    config.plugins.push(new webpack.LoaderOptionsPlugin({
+        minimize: true,
+        debug: false,
+        options: {
+            context: __dirname
+        }
+    }));
 }
 
 module.exports = config


### PR DESCRIPTION
This will speed up local development and CI runs (5s vs 30s)