### PR TITLE
Use gzip middlerware to compress responses if client can accept compr…

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -45,6 +45,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/gin-contrib/gzip"
+  packages = ["."]
+  revision = "ff223ab9f8e3e69d4eb333c90966e057c5a97873"
+
+[[projects]]
+  branch = "master"
   name = "github.com/gin-contrib/sse"
   packages = ["."]
   revision = "22d885f9ecc78bf4ee5d72b937e4bbcdc58e8cae"
@@ -172,6 +178,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7f8053eae7793a1bf95a91da813f86e38bf12678ad493d01c3f25864249dd305"
+  inputs-digest = "32bf99922b6d83811ed209762176a18be21b3a747affed35d9b6a266d53434b6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cloudflare/unsee/internal/transform"
 
 	"github.com/DeanThompson/ginpprof"
+	"github.com/gin-contrib/gzip"
 	"github.com/gin-contrib/static"
 	"github.com/gin-gonic/contrib/sentry"
 	"github.com/gin-gonic/gin"
@@ -45,6 +46,7 @@ func getViewURL(sub string) string {
 }
 
 func setupRouter(router *gin.Engine) {
+	router.Use(gzip.Gzip(gzip.DefaultCompression))
 	router.Use(static.Serve(getViewURL("/static"), newBinaryFileSystem("static")))
 
 	router.GET(getViewURL("/favicon.ico"), favicon)


### PR DESCRIPTION
…essed content

Some alert.json responses are going to be big, compress it to save bandwidth