### PR TITLE
Enable source map generation in UglifyJsPlugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -112,7 +112,9 @@ const isDev = (process.env.NODE_ENV === "test");
 
 // enable production only plugins
 if (!isDev) {
-    config.plugins.push(new webpack.optimize.UglifyJsPlugin());
+    config.plugins.push(new webpack.optimize.UglifyJsPlugin({
+        sourceMap: true
+    }));
     config.plugins.push(new webpack.LoaderOptionsPlugin({
         minimize: true,
         debug: false,


### PR DESCRIPTION
Looks like it was disabled at some point and depending on the version of webpack it's enabled by default or not:
https://github.com/webpack/webpack/issues/2704#issuecomment-228860162

So it was working with 3.3.0 but now fails with 3.4.1, this PR fixes it