### PR TITLE
Don't reload filters until entire applyFilterList() block was completed

### DIFF
--- a/assets/static/filters.js
+++ b/assets/static/filters.js
@@ -56,23 +56,6 @@ function addFilter(text) {
     $(selectors.filter).tagsinput("add", text);
 }
 
-function applyFilterList(filterList) {
-    // we need to add filters one by one, this would reload alerts on every
-    // add() so let's pause reloads and resume once we're done with updating
-    // filters
-    unsee.pause();
-    // disable history appends as it would record each new filter in the
-    // history
-    appendsEnabled = false;
-    $(selectors.filter).tagsinput("removeAll");
-    for (var i = 0; i < filterList.length; i++) {
-        $(selectors.filter).tagsinput("add", filterList[i]);
-    }
-    // enable everything again
-    appendsEnabled = true;
-    unsee.resume();
-}
-
 function clearFilters() {
     $(selectors.filter).tagsinput("removeAll");
 }
@@ -146,6 +129,24 @@ function setFilters() {
     unsee.triggerReload();
 }
 
+function applyFilterList(filterList) {
+    // we need to add filters one by one, this would reload alerts on every
+    // add() so let's pause reloads and resume once we're done with updating
+    // filters
+    unsee.pause();
+    // disable history appends as it would record each new filter in the
+    // history
+    appendsEnabled = false;
+    $(selectors.filter).tagsinput("removeAll");
+    for (var i = 0; i < filterList.length; i++) {
+        $(selectors.filter).tagsinput("add", filterList[i]);
+    }
+    // enable everything again
+    appendsEnabled = true;
+    setFilters();
+    unsee.resume();
+}
+
 function init(historyStore) {
     historyStorage = historyStore;
     var initialFilter;
@@ -179,7 +180,12 @@ function init(historyStore) {
     });
 
     $(selectors.filter).on("itemAdded itemRemoved", function(event) {
-        setFilters();
+        if (appendsEnabled) {
+            // if history appends are disabled then don't set filters yet
+            // we disable appends to have batch filter updates so we shouldn't
+            // set filters yet
+            setFilters();
+        }
         // add counter badge to new tag
         if (event.type == "itemAdded") {
             addBadge(event.item);


### PR DESCRIPTION
setFilters() will trigger fetch of the new alerts with updated filter, it's being called after each filter is added to the filter bar, so each added filter ends up with AJAX call to /alerts.json, this means that when someone clicks on a history entry with complex rule it will trigger multiple subsequent requests. What's worse first request will have bigger response body (since it filters less) so it's likely that it will finish after the next request, leaving invalid alerts on the grid. This disable setFilters() if we apply filters in batch mode.