### PR TITLE
Add REMOVE_RECEIVERS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,21 @@ This option can also be set using `-strip.labels` flag. Example:
 
 This variable is optional and default is not set (all labels will be shown).
 
+#### STRIP_RECEIVERS
+
+List of receiver names that should not be shown on the UI. This allows to hide
+all alerts for receivers that are not needed on the alert dashboard. Accepts
+space separated list of receiver names. Examples:
+
+    STRIP_RECEIVERS=hipchat-test
+    STRIP_RECEIVERS="hipchat-test blackhole"
+
+This option can also be set using `-strip.receivers` flag. Example:
+
+    $ unsee -strip.receivers "hipchat-test blackhole"
+
+This variable is optional and default is not set (all receivers will be shown).
+
 #### WEB_PREFIX
 
 URL root for unsee, you can use to if you wish to serve it from location other

--- a/internal/alertmanager/dedup.go
+++ b/internal/alertmanager/dedup.go
@@ -63,6 +63,11 @@ func DedupAlerts() []models.AlertGroup {
 		ag := models.AlertGroup(agList[0])
 		ag.Alerts = models.AlertList{}
 		for _, alert := range alerts {
+			// remove all alerts for receiver(s) that the user doesn't
+			// want to see in the UI
+			if transform.StripReceivers(config.Config.StripReceivers, alert.Receiver) {
+				continue
+			}
 			// strip labels user doesn't want to see in the UI
 			alert.Labels = transform.StripLables(config.Config.KeepLabels, config.Config.StripLabels, alert.Labels)
 			// calculate final alert state based on the most important value found

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,7 @@ type configEnvs struct {
 	SentryDSN                string             `envconfig:"SENTRY_DSN" help:"Sentry DSN for Go exceptions"`
 	SentryPublicDSN          string             `envconfig:"SENTRY_PUBLIC_DSN" help:"Sentry DSN for javascript exceptions"`
 	StripLabels              spaceSeparatedList `envconfig:"STRIP_LABELS" help:"List of labels to ignore"`
+	StripReceivers           spaceSeparatedList `envconfig:"STRIP_RECEIVERS" help:"List of receivers to not display alerts for"`
 	KeepLabels               spaceSeparatedList `envconfig:"KEEP_LABELS" help:"List of labels to keep, all other labels will be stripped"`
 	WebPrefix                string             `envconfig:"WEB_PREFIX" default:"/" help:"URL prefix"`
 }

--- a/internal/transform/strip.go
+++ b/internal/transform/strip.go
@@ -26,3 +26,13 @@ func StripLables(keptLabels, ignoredLabels []string, sourceLabels map[string]str
 	}
 	return labels
 }
+
+// StripReceivers allows filtering all alerts for specified receiver(s)
+func StripReceivers(ignoredReceivers []string, alertReceiver string) bool {
+	for _, ignoredReceiver := range ignoredReceivers {
+		if alertReceiver == ignoredReceiver {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This option allows for all alerts for a specified receiver, or list of
receivers, to be removed from unsee.

My use case for this is using a receiver for auto-remediation which will
contain information that the user will never need to see in the UI.