### PR TITLE
Travis build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,44 @@
-language: go
-
-go:
-  - 1.9.x
-
 go_import_path: github.com/cloudflare/unsee
 
-cache:
-  directories:
-    - node_modules
-    - vendor
+jobs:
+  include:
+    - stage: Test Go code
+      language: go
+      go:  "1.9.2"
+      before_script:
+        - make mock-assets
+      cache:
+        directories:
+          - vendor
+      script: make test-go
 
-env:
-  - NODE_ENV=test
+    - stage: Test JavaScript code
+      language: node_js
+      node_js: "8"
+      env:
+        - NODE_ENV=test
+      cache:
+        directories:
+          - node_modules
+      script: make test-js
 
-before_script:
-  - nvm install 8
+    - stage: Lint Go code
+      language: go
+      go:  "1.9.2"
+      script: make lint-go
 
-script:
-  - make test
+    - stage: Lint JavaScript code
+      language: node_js
+      node_js: "8"
+      cache:
+        directories:
+          - node_modules
+      script: make lint-js
+
+    - stage: Build Docker image
+      sudo: true
+      addons:
+        apt:
+          packages:
+            - docker-ce
+      script: make docker-image

--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,9 @@ lint: lint-go lint-js
 
 # Creates mock bindata_assetfs.go with source assets rather than webpack generated ones
 .PHONY: mock-assets
-mock-assets: .build/deps.ok .build/vendor.ok
-	cp $(CURDIR)/assets/static/*.* $(CURDIR)/assets/static/dist/
+mock-assets: .build/go-bindata .build/go-bindata-assetfs
 	mkdir -p $(CURDIR)/assets/static/dist/templates
+	cp $(CURDIR)/assets/static/*.* $(CURDIR)/assets/static/dist/
 	touch $(CURDIR)/assets/static/dist/templates/loader_unsee.html
 	touch $(CURDIR)/assets/static/dist/templates/loader_shared.html
 	touch $(CURDIR)/assets/static/dist/templates/loader_help.html


### PR DESCRIPTION
Split up all tasks run on Travis CI into stages.
This slows down CI jobs (~3m -> ~6m), but isolates different tests and makes it more obvious what failed.
Isolating jobs allows to add new jobs easily, like doing a test build of a docker image, which now happens (and slows things down even more, with extra 4m more needed).