### PR TITLE
Hide sentry secrets in startup logs

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -168,6 +168,11 @@ func (config *configSchema) LogValues() {
 	}
 	cfg.Alertmanager.Servers = servers
 
+	// replace secret in Sentry DNS with 'xxx'
+	if config.Sentry.Private != "" {
+		config.Sentry.Private = hideURLPassword(config.Sentry.Private)
+	}
+
 	out, err := yaml.Marshal(cfg)
 	if err != nil {
 		log.Error(err)


### PR DESCRIPTION
No need to leak sentry secrets in the internal DSN