### PR TITLE
3 stage build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ jobs:
       cache:
         directories:
           - node_modules
+      # install defaults to "npm install", which is done via make
+      install: []
       script: make test-js
 
     - stage: Lint Go code
@@ -33,6 +35,8 @@ jobs:
       cache:
         directories:
           - node_modules
+      # install defaults to "npm install", which is done via make
+      install: []
       script: make lint-js
 
     - stage: Build Docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM golang:1.9.2-alpine3.6 as unsee-builder
-COPY . /go/src/github.com/cloudflare/unsee
+FROM node:8-alpine as nodejs-builder
+RUN apk add --update make git
+COPY . /unsee
+RUN make -C /unsee webpack
 
+FROM golang:1.9.2-alpine3.6 as go-builder
+COPY --from=nodejs-builder /unsee /go/src/github.com/cloudflare/unsee
 ARG VERSION
-RUN apk add --update make git nodejs nodejs-npm
+RUN apk add --update make git
 RUN CGO_ENABLED=0 make -C /go/src/github.com/cloudflare/unsee VERSION="${VERSION:-dev}" unsee
 
 FROM gcr.io/distroless/base
-COPY --from=unsee-builder /go/src/github.com/cloudflare/unsee/unsee /unsee
+COPY --from=go-builder /go/src/github.com/cloudflare/unsee/unsee /unsee
 EXPOSE 8080
 CMD ["/unsee"]


### PR DESCRIPTION
I've noticed that the docker images we use are running old nodejs version - https://travis-ci.org/cloudflare/unsee/jobs/311602111#L529
As a result dependencies aren't correctly enforced when building docker image - https://travis-ci.org/cloudflare/unsee/jobs/311602111#L1573

Using separate nodejs and Go images seems like the best solution. Makefile cleanup was needed to add this. With this PR all nodejs deps are installed in the correct version - https://travis-ci.org/cloudflare/unsee/jobs/311697485#L558