### PR TITLE
Show silence ID in the UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ test-go: .build/vendor.ok
 	go test -bench=. -cover `go list ./... | grep -v /vendor/`
 
 .PHONY: test-js
-test-js:
+test-js: .build/deps-build-node.ok
 	npm test
 
 .PHONY: test

--- a/assets/static/unsee.js
+++ b/assets/static/unsee.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const $ = window.$ = window.jQuery = require("jquery");
+const Clipboard = require("clipboard");
 const moment = require("moment");
 const Raven = require("raven-js");
 
@@ -43,6 +44,7 @@ var selectors = {
     refreshButton: "#refresh",
     errors: "#errors",
     instanceErrors: "#instance-errors",
+    clickToCopy: ".click-to-copy"
 };
 
 function parseAJAXError(xhr, textStatus) {
@@ -340,6 +342,16 @@ function onReady(localStore) {
         // enable tooltips, #settings is a dropdown so it already uses different data-toggle
         $("[data-toggle='tooltip'], #settings, #history").tooltip({
             trigger: "hover"
+        });
+
+        var clipboard = new Clipboard(selectors.clickToCopy);
+        clipboard.on("success", function(e) {
+            // flash element after copy
+            $(e.trigger).finish().fadeOut(100).fadeIn(300);
+            // hide tooltip after flash
+            $(e.trigger).tooltip("hide");
+            // reset focus
+            e.clearSelection();
         });
 
         colors.init($("#alerts").data("static-color-labels").split(" "));

--- a/assets/templates/alertgroup.html
+++ b/assets/templates/alertgroup.html
@@ -150,6 +150,13 @@
               <%- am.name %>
             </div>
           <% } %>
+          <div class="label label-list label-default cursor-pointer click-to-copy"
+             title="Click to copy this silence ID to clipboard"
+             data-toggle="tooltip"
+             data-placement="top"
+             data-clipboard-text="<%- silence.id %>">
+             <%- silence.id %>
+          </div>
           <div class="label label-list label-default label-age label-ts cursor-help"
              data-toggle="tooltip"
              data-placement="top"


### PR DESCRIPTION
This adds silence ID to the list of rendered silence elements, clicking on it will allow to copy it to the clipboard. Fixes #203