### PR TITLE
Add a stage for linting .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ jobs:
       script: make lint-js
 
     - stage: Build Docker image
+      language: generic
       sudo: true
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@ go_import_path: github.com/cloudflare/unsee
 
 jobs:
   include:
+    - stage: Lint Travis CI configuration
+      language: ruby
+      before_script:
+        - gem install travis --no-rdoc --no-ri
+      script:
+        - travis lint -x --no-interactive .travis.yml
+
     - stage: Test Go code
       language: go
       go:  "1.9.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-go_import_path: github.com/cloudflare/unsee
-
 jobs:
   include:
     - stage: Lint Travis CI configuration


### PR DESCRIPTION
We shouldn't run CI job if CI job config is borked, this should help catch that
