### PR TITLE
Mapper package refactoring

### DIFF
--- a/internal/alertmanager/dedup_test.go
+++ b/internal/alertmanager/dedup_test.go
@@ -17,7 +17,10 @@ func init() {
 	log.SetLevel(log.ErrorLevel)
 	for i, uri := range mock.ListAllMockURIs() {
 		name := fmt.Sprintf("dedup-mock-%d", i)
-		am := alertmanager.NewAlertmanager(name, uri, alertmanager.WithRequestTimeout(time.Second))
+		am, err := alertmanager.NewAlertmanager(name, uri, alertmanager.WithRequestTimeout(time.Second))
+		if err != nil {
+			log.Fatal(err)
+		}
 		alertmanager.RegisterAlertmanager(am)
 	}
 }

--- a/internal/alertmanager/upstream.go
+++ b/internal/alertmanager/upstream.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/cloudflare/unsee/internal/models"
+	"github.com/cloudflare/unsee/internal/transport"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -18,7 +19,7 @@ var (
 )
 
 // NewAlertmanager creates a new Alertmanager instance
-func NewAlertmanager(name, uri string, opts ...Option) *Alertmanager {
+func NewAlertmanager(name, uri string, opts ...Option) (*Alertmanager, error) {
 	am := &Alertmanager{
 		URI:            uri,
 		RequestTimeout: time.Second * 10,
@@ -40,7 +41,13 @@ func NewAlertmanager(name, uri string, opts ...Option) *Alertmanager {
 		opt(am)
 	}
 
-	return am
+	var err error
+	am.transport, err = transport.NewTransport(am.URI, am.RequestTimeout)
+	if err != nil {
+		return am, err
+	}
+
+	return am, nil
 }
 
 // RegisterAlertmanager will add an Alertmanager instance to the list of

--- a/internal/alertmanager/version.go
+++ b/internal/alertmanager/version.go
@@ -1,6 +1,7 @@
 package alertmanager
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/cloudflare/unsee/internal/transport"
@@ -30,7 +31,15 @@ func GetVersion(uri string, timeout time.Duration) string {
 		return defaultVersion
 	}
 	ver := alertmanagerVersion{}
-	err = transport.ReadJSON(url, timeout, &ver)
+
+	t, err := transport.NewTransport(uri, timeout)
+	if err != nil {
+		log.Errorf("Unable to get the version information from %s", url)
+		return defaultVersion
+	}
+
+	source, err := t.Read(url)
+	err = json.NewDecoder(source).Decode(&ver)
 	if err != nil {
 		log.Errorf("%s request failed: %s", url, err.Error())
 		return defaultVersion

--- a/internal/filters/filter_test.go
+++ b/internal/filters/filter_test.go
@@ -485,7 +485,10 @@ var tests = []filterTest{
 func TestFilters(t *testing.T) {
 	log.SetLevel(log.ErrorLevel)
 
-	am := alertmanager.NewAlertmanager("test", "http://localhost", alertmanager.WithRequestTimeout(time.Second))
+	am, err := alertmanager.NewAlertmanager("test", "http://localhost", alertmanager.WithRequestTimeout(time.Second))
+	if err != nil {
+		t.Error(err)
+	}
 	for _, ft := range tests {
 		alert := models.Alert(ft.Alert)
 		if &ft.Silence != nil {

--- a/internal/mapper/mapper.go
+++ b/internal/mapper/mapper.go
@@ -28,7 +28,6 @@ type AlertMapper interface {
 type SilenceMapper interface {
 	Mapper
 	Decode(io.ReadCloser) ([]models.Silence, error)
-	Release() string
 }
 
 // RegisterAlertMapper allows to register mapper implementing alert data

--- a/internal/mapper/mapper.go
+++ b/internal/mapper/mapper.go
@@ -12,15 +12,19 @@ var (
 	silenceMappers = []SilenceMapper{}
 )
 
+// Mapper converts Alertmanager response body and maps to unsee data structures
 type Mapper interface {
 	IsSupported(version string) bool
+	AbsoluteURL(baseURI string) (string, error)
 }
 
+// AlertMapper handles mapping of Alertmanager alert information to unsee AlertGroup models
 type AlertMapper interface {
 	Mapper
 	Decode(io.ReadCloser) ([]models.AlertGroup, error)
 }
 
+// SilenceMapper handles mapping of Alertmanager silence information to unsee Silence models
 type SilenceMapper interface {
 	Mapper
 	Decode(io.ReadCloser) ([]models.Silence, error)

--- a/internal/mapper/v04/alerts.go
+++ b/internal/mapper/v04/alerts.go
@@ -5,7 +5,9 @@
 package v04
 
 import (
+	"encoding/json"
 	"errors"
+	"io"
 	"sort"
 	"strconv"
 	"time"
@@ -13,7 +15,6 @@ import (
 	"github.com/blang/semver"
 	"github.com/cloudflare/unsee/internal/mapper"
 	"github.com/cloudflare/unsee/internal/models"
-	"github.com/cloudflare/unsee/internal/transport"
 )
 
 type alert struct {
@@ -58,19 +59,13 @@ func (m AlertMapper) IsSupported(version string) bool {
 	return versionRange(semver.MustParse(version))
 }
 
-// GetAlerts will make a request to Alertmanager API and parse the response
-// It will only return alerts or error (if any)
-func (m AlertMapper) GetAlerts(uri string, timeout time.Duration) ([]models.AlertGroup, error) {
+func (m AlertMapper) Decode(source io.ReadCloser) ([]models.AlertGroup, error) {
 	groups := []models.AlertGroup{}
 	receivers := map[string]alertsGroupReceiver{}
 	resp := alertsGroupsAPISchema{}
 
-	url, err := transport.JoinURL(uri, "api/v1/alerts/groups")
-	if err != nil {
-		return groups, err
-	}
-
-	err = transport.ReadJSON(url, timeout, &resp)
+	defer source.Close()
+	err := json.NewDecoder(source).Decode(resp)
 	if err != nil {
 		return groups, err
 	}

--- a/internal/mapper/v04/alerts.go
+++ b/internal/mapper/v04/alerts.go
@@ -15,6 +15,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/cloudflare/unsee/internal/mapper"
 	"github.com/cloudflare/unsee/internal/models"
+	"github.com/cloudflare/unsee/internal/transport"
 )
 
 type alert struct {
@@ -53,19 +54,25 @@ type AlertMapper struct {
 	mapper.AlertMapper
 }
 
+// AbsoluteURL for alerts API endpoint this mapper supports
+func (m AlertMapper) AbsoluteURL(baseURI string) (string, error) {
+	return transport.JoinURL(baseURI, "api/v1/alerts/groups")
+}
+
 // IsSupported returns true if given version string is supported
 func (m AlertMapper) IsSupported(version string) bool {
 	versionRange := semver.MustParseRange(">=0.4.0 <0.5.0")
 	return versionRange(semver.MustParse(version))
 }
 
+// Decode Alertmanager API response body and return unsee model instances
 func (m AlertMapper) Decode(source io.ReadCloser) ([]models.AlertGroup, error) {
 	groups := []models.AlertGroup{}
 	receivers := map[string]alertsGroupReceiver{}
 	resp := alertsGroupsAPISchema{}
 
 	defer source.Close()
-	err := json.NewDecoder(source).Decode(resp)
+	err := json.NewDecoder(source).Decode(&resp)
 	if err != nil {
 		return groups, err
 	}

--- a/internal/mapper/v04/silences.go
+++ b/internal/mapper/v04/silences.go
@@ -5,16 +5,15 @@
 package v04
 
 import (
+	"encoding/json"
 	"errors"
-	"fmt"
-	"math"
+	"io"
 	"strconv"
 	"time"
 
 	"github.com/blang/semver"
 	"github.com/cloudflare/unsee/internal/mapper"
 	"github.com/cloudflare/unsee/internal/models"
-	"github.com/cloudflare/unsee/internal/transport"
 )
 
 // Alertmanager 0.4 silence format
@@ -53,20 +52,12 @@ func (m SilenceMapper) IsSupported(version string) bool {
 	return versionRange(semver.MustParse(version))
 }
 
-// GetSilences will make a request to Alertmanager API and parse the response
-// It will only return silences or error (if any)
-func (m SilenceMapper) GetSilences(uri string, timeout time.Duration) ([]models.Silence, error) {
+func (m SilenceMapper) Decode(source io.ReadCloser) ([]models.Silence, error) {
 	silences := []models.Silence{}
 	resp := silenceAPISchema{}
 
-	url, err := transport.JoinURL(uri, "api/v1/silences")
-	if err != nil {
-		return silences, err
-	}
-
-	// Alertmanager 0.4 uses pagination for silences
-	url = fmt.Sprintf("%s?limit=%d", url, math.MaxUint32)
-	err = transport.ReadJSON(url, timeout, &resp)
+	defer source.Close()
+	err := json.NewDecoder(source).Decode(resp)
 	if err != nil {
 		return silences, err
 	}

--- a/internal/mapper/v04/silences.go
+++ b/internal/mapper/v04/silences.go
@@ -14,6 +14,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/cloudflare/unsee/internal/mapper"
 	"github.com/cloudflare/unsee/internal/models"
+	"github.com/cloudflare/unsee/internal/transport"
 )
 
 // Alertmanager 0.4 silence format
@@ -46,18 +47,24 @@ type SilenceMapper struct {
 	mapper.SilenceMapper
 }
 
+// AbsoluteURL for silences API endpoint this mapper supports
+func (m SilenceMapper) AbsoluteURL(baseURI string) (string, error) {
+	return transport.JoinURL(baseURI, "api/v1/silences")
+}
+
 // IsSupported returns true if given version string is supported
 func (m SilenceMapper) IsSupported(version string) bool {
 	versionRange := semver.MustParseRange(">=0.4.0 <0.5.0")
 	return versionRange(semver.MustParse(version))
 }
 
+// Decode Alertmanager API response body and return unsee model instances
 func (m SilenceMapper) Decode(source io.ReadCloser) ([]models.Silence, error) {
 	silences := []models.Silence{}
 	resp := silenceAPISchema{}
 
 	defer source.Close()
-	err := json.NewDecoder(source).Decode(resp)
+	err := json.NewDecoder(source).Decode(&resp)
 	if err != nil {
 		return silences, err
 	}

--- a/internal/mapper/v05/alerts.go
+++ b/internal/mapper/v05/alerts.go
@@ -5,14 +5,15 @@
 package v05
 
 import (
+	"encoding/json"
 	"errors"
+	"io"
 	"sort"
 	"time"
 
 	"github.com/blang/semver"
 	"github.com/cloudflare/unsee/internal/mapper"
 	"github.com/cloudflare/unsee/internal/models"
-	"github.com/cloudflare/unsee/internal/transport"
 )
 
 type alert struct {
@@ -57,19 +58,13 @@ func (m AlertMapper) IsSupported(version string) bool {
 	return versionRange(semver.MustParse(version))
 }
 
-// GetAlerts will make a request to Alertmanager API and parse the response
-// It will only return alerts or error (if any)
-func (m AlertMapper) GetAlerts(uri string, timeout time.Duration) ([]models.AlertGroup, error) {
+func (m AlertMapper) Decode(source io.ReadCloser) ([]models.AlertGroup, error) {
 	groups := []models.AlertGroup{}
 	receivers := map[string]alertsGroupReceiver{}
 	resp := alertsGroupsAPISchema{}
 
-	url, err := transport.JoinURL(uri, "api/v1/alerts/groups")
-	if err != nil {
-		return groups, err
-	}
-
-	err = transport.ReadJSON(url, timeout, &resp)
+	defer source.Close()
+	err := json.NewDecoder(source).Decode(resp)
 	if err != nil {
 		return groups, err
 	}

--- a/internal/mapper/v05/alerts.go
+++ b/internal/mapper/v05/alerts.go
@@ -14,6 +14,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/cloudflare/unsee/internal/mapper"
 	"github.com/cloudflare/unsee/internal/models"
+	"github.com/cloudflare/unsee/internal/transport"
 )
 
 type alert struct {
@@ -52,19 +53,25 @@ type AlertMapper struct {
 	mapper.AlertMapper
 }
 
+// AbsoluteURL for alerts API endpoint this mapper supports
+func (m AlertMapper) AbsoluteURL(baseURI string) (string, error) {
+	return transport.JoinURL(baseURI, "api/v1/alerts/groups")
+}
+
 // IsSupported returns true if given version string is supported
 func (m AlertMapper) IsSupported(version string) bool {
 	versionRange := semver.MustParseRange(">=0.5.0  <=0.6.0")
 	return versionRange(semver.MustParse(version))
 }
 
+// Decode Alertmanager API response body and return unsee model instances
 func (m AlertMapper) Decode(source io.ReadCloser) ([]models.AlertGroup, error) {
 	groups := []models.AlertGroup{}
 	receivers := map[string]alertsGroupReceiver{}
 	resp := alertsGroupsAPISchema{}
 
 	defer source.Close()
-	err := json.NewDecoder(source).Decode(resp)
+	err := json.NewDecoder(source).Decode(&resp)
 	if err != nil {
 		return groups, err
 	}

--- a/internal/mapper/v05/silences.go
+++ b/internal/mapper/v05/silences.go
@@ -13,6 +13,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/cloudflare/unsee/internal/mapper"
 	"github.com/cloudflare/unsee/internal/models"
+	"github.com/cloudflare/unsee/internal/transport"
 )
 
 type silence struct {
@@ -40,18 +41,24 @@ type SilenceMapper struct {
 	mapper.SilenceMapper
 }
 
+// AbsoluteURL for silences API endpoint this mapper supports
+func (m SilenceMapper) AbsoluteURL(baseURI string) (string, error) {
+	return transport.JoinURL(baseURI, "api/v1/silences")
+}
+
 // IsSupported returns true if given version string is supported
 func (m SilenceMapper) IsSupported(version string) bool {
 	versionRange := semver.MustParseRange(">=0.5.0")
 	return versionRange(semver.MustParse(version))
 }
 
+// Decode Alertmanager API response body and return unsee model instances
 func (m SilenceMapper) Decode(source io.ReadCloser) ([]models.Silence, error) {
 	silences := []models.Silence{}
 	resp := silenceAPISchema{}
 
 	defer source.Close()
-	err := json.NewDecoder(source).Decode(resp)
+	err := json.NewDecoder(source).Decode(&resp)
 	if err != nil {
 		return silences, err
 	}

--- a/internal/mapper/v061/alerts.go
+++ b/internal/mapper/v061/alerts.go
@@ -6,14 +6,15 @@
 package v061
 
 import (
+	"encoding/json"
 	"errors"
+	"io"
 	"sort"
 	"time"
 
 	"github.com/blang/semver"
 	"github.com/cloudflare/unsee/internal/mapper"
 	"github.com/cloudflare/unsee/internal/models"
-	"github.com/cloudflare/unsee/internal/transport"
 )
 
 type alert struct {
@@ -59,19 +60,13 @@ func (m AlertMapper) IsSupported(version string) bool {
 	return versionRange(semver.MustParse(version))
 }
 
-// GetAlerts will make a request to Alertmanager API and parse the response
-// It will only return alerts or error (if any)
-func (m AlertMapper) GetAlerts(uri string, timeout time.Duration) ([]models.AlertGroup, error) {
+func (m AlertMapper) Decode(source io.ReadCloser) ([]models.AlertGroup, error) {
 	groups := []models.AlertGroup{}
 	receivers := map[string]alertsGroupReceiver{}
 	resp := alertsGroupsAPISchema{}
 
-	url, err := transport.JoinURL(uri, "api/v1/alerts/groups")
-	if err != nil {
-		return groups, err
-	}
-
-	err = transport.ReadJSON(url, timeout, &resp)
+	defer source.Close()
+	err := json.NewDecoder(source).Decode(resp)
 	if err != nil {
 		return groups, err
 	}

--- a/internal/mapper/v061/alerts.go
+++ b/internal/mapper/v061/alerts.go
@@ -15,6 +15,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/cloudflare/unsee/internal/mapper"
 	"github.com/cloudflare/unsee/internal/models"
+	"github.com/cloudflare/unsee/internal/transport"
 )
 
 type alert struct {
@@ -54,19 +55,25 @@ type AlertMapper struct {
 	mapper.AlertMapper
 }
 
+// AbsoluteURL for alerts API endpoint this mapper supports
+func (m AlertMapper) AbsoluteURL(baseURI string) (string, error) {
+	return transport.JoinURL(baseURI, "api/v1/alerts/groups")
+}
+
 // IsSupported returns true if given version string is supported
 func (m AlertMapper) IsSupported(version string) bool {
 	versionRange := semver.MustParseRange("=0.6.1")
 	return versionRange(semver.MustParse(version))
 }
 
+// Decode Alertmanager API response body and return unsee model instances
 func (m AlertMapper) Decode(source io.ReadCloser) ([]models.AlertGroup, error) {
 	groups := []models.AlertGroup{}
 	receivers := map[string]alertsGroupReceiver{}
 	resp := alertsGroupsAPISchema{}
 
 	defer source.Close()
-	err := json.NewDecoder(source).Decode(resp)
+	err := json.NewDecoder(source).Decode(&resp)
 	if err != nil {
 		return groups, err
 	}

--- a/internal/mapper/v062/alerts.go
+++ b/internal/mapper/v062/alerts.go
@@ -6,14 +6,15 @@
 package v062
 
 import (
+	"encoding/json"
 	"errors"
+	"io"
 	"sort"
 	"time"
 
 	"github.com/blang/semver"
 	"github.com/cloudflare/unsee/internal/mapper"
 	"github.com/cloudflare/unsee/internal/models"
-	"github.com/cloudflare/unsee/internal/transport"
 )
 
 type alertStatus struct {
@@ -63,19 +64,13 @@ func (m AlertMapper) IsSupported(version string) bool {
 	return versionRange(semver.MustParse(version))
 }
 
-// GetAlerts will make a request to Alertmanager API and parse the response
-// It will only return alerts or error (if any)
-func (m AlertMapper) GetAlerts(uri string, timeout time.Duration) ([]models.AlertGroup, error) {
+func (m AlertMapper) Decode(source io.ReadCloser) ([]models.AlertGroup, error) {
 	groups := []models.AlertGroup{}
 	receivers := map[string]alertsGroupReceiver{}
 	resp := alertsGroupsAPISchema{}
 
-	url, err := transport.JoinURL(uri, "api/v1/alerts/groups")
-	if err != nil {
-		return groups, err
-	}
-
-	err = transport.ReadJSON(url, timeout, &resp)
+	defer source.Close()
+	err := json.NewDecoder(source).Decode(resp)
 	if err != nil {
 		return groups, err
 	}

--- a/internal/mapper/v062/alerts.go
+++ b/internal/mapper/v062/alerts.go
@@ -15,6 +15,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/cloudflare/unsee/internal/mapper"
 	"github.com/cloudflare/unsee/internal/models"
+	"github.com/cloudflare/unsee/internal/transport"
 )
 
 type alertStatus struct {
@@ -58,19 +59,25 @@ type AlertMapper struct {
 	mapper.AlertMapper
 }
 
+// AbsoluteURL for alerts API endpoint this mapper supports
+func (m AlertMapper) AbsoluteURL(baseURI string) (string, error) {
+	return transport.JoinURL(baseURI, "api/v1/alerts/groups")
+}
+
 // IsSupported returns true if given version string is supported
 func (m AlertMapper) IsSupported(version string) bool {
 	versionRange := semver.MustParseRange(">=0.6.2")
 	return versionRange(semver.MustParse(version))
 }
 
+// Decode Alertmanager API response body and return unsee model instances
 func (m AlertMapper) Decode(source io.ReadCloser) ([]models.AlertGroup, error) {
 	groups := []models.AlertGroup{}
 	receivers := map[string]alertsGroupReceiver{}
 	resp := alertsGroupsAPISchema{}
 
 	defer source.Close()
-	err := json.NewDecoder(source).Decode(resp)
+	err := json.NewDecoder(source).Decode(&resp)
 	if err != nil {
 		return groups, err
 	}

--- a/internal/transport/file.go
+++ b/internal/transport/file.go
@@ -2,14 +2,16 @@ package transport
 
 import (
 	"io"
+	"net/url"
 	"os"
+	"path"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
 
 type fileReader struct {
-	filename string
-	fd       *os.File
+	fd *os.File
 }
 
 func (fr *fileReader) Read(b []byte) (n int, err error) {
@@ -20,9 +22,37 @@ func (fr *fileReader) Close() error {
 	return fr.fd.Close()
 }
 
-func newFileReader(filname string) (io.ReadCloser, error) {
-	log.Infof("Reading file '%s'", filname)
-	fd, err := os.Open(filname)
-	fr := fileReader{filename: filname, fd: fd}
+// FileTransport can read data from file:// URIs
+type FileTransport struct {
+}
+
+func (t *FileTransport) pathFromURI(uri string) (string, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return "", err
+	}
+
+	// if we have a file URI with relative path we need to expand it into an
+	// absolute path, url.Parse doesn't support relative file paths
+	if strings.HasPrefix(uri, "file:///") {
+		return u.Path, nil
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	absolutePath := path.Join(wd, strings.TrimPrefix(uri, "file://"))
+	return absolutePath, nil
+}
+
+func (t *FileTransport) Read(uri string) (io.ReadCloser, error) {
+	filename, err := t.pathFromURI(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Infof("Reading file '%s'", filename)
+	fd, err := os.Open(filename)
+	fr := fileReader{fd: fd}
 	return &fr, err
 }

--- a/main.go
+++ b/main.go
@@ -60,10 +60,13 @@ func setupRouter(router *gin.Engine) {
 
 func setupUpstreams() {
 	for _, s := range config.Config.Alertmanager.Servers {
-		am := alertmanager.NewAlertmanager(s.Name, s.URI, alertmanager.WithRequestTimeout(s.Timeout), alertmanager.WithProxy(s.Proxy))
-		err := alertmanager.RegisterAlertmanager(am)
+		am, err := alertmanager.NewAlertmanager(s.Name, s.URI, alertmanager.WithRequestTimeout(s.Timeout), alertmanager.WithProxy(s.Proxy))
 		if err != nil {
-			log.Fatalf("Failed to configure Alertmanager '%s' with URI '%s': %s", s.Name, s.URI, err)
+			log.Fatalf("Failed to create Alertmanager '%s' with URI '%s': %s", s.Name, s.URI, err)
+		}
+		err = alertmanager.RegisterAlertmanager(am)
+		if err != nil {
+			log.Fatalf("Failed to register Alertmanager '%s' with URI '%s': %s", s.Name, s.URI, err)
 		}
 	}
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -90,12 +90,15 @@ var proxyTests = []proxyTest{
 
 func TestProxy(t *testing.T) {
 	r := ginTestEngine()
-	am := alertmanager.NewAlertmanager(
+	am, err := alertmanager.NewAlertmanager(
 		"dummy",
 		"http://localhost:9093",
 		alertmanager.WithRequestTimeout(time.Second*5),
 		alertmanager.WithProxy(true),
 	)
+	if err != nil {
+		t.Error(err)
+	}
 	setupRouterProxyHandlers(r, am)
 
 	httpmock.Activate()


### PR DESCRIPTION
To address comment from #207 some cleanups are needed, mostly around responsibilities of each sub-package, which this PR aims to resolve.
`mapper` is now a `Alertmanager API response body` -> `unsee objects` mapping code, which I think makes more sense, and it doesn't do any request handling anymore
`transport` was refactored to allow passing it to the `Alertmanager` instance (which we create for each AM upstream), so we no longer need to pass timeouts or tls.Config around.

This is 90% done, need to re-read changes here and likely cleanup a few things