### PR TITLE
Allow passing query args to HTTP requests send to the Alertmanager API

### DIFF
--- a/internal/alertmanager/models.go
+++ b/internal/alertmanager/models.go
@@ -115,6 +115,11 @@ func (am *Alertmanager) pullSilences(version string) error {
 		log.Errorf("[%s] Failed to generate silences endpoint URL: %s", am.Name, err)
 		return err
 	}
+	// append query args if mapper needs those
+	queryArgs := mapper.QueryArgs()
+	if queryArgs != "" {
+		url = fmt.Sprintf("%s?%s", url, queryArgs)
+	}
 
 	start := time.Now()
 	// read raw body from the source
@@ -173,6 +178,12 @@ func (am *Alertmanager) pullAlerts(version string) error {
 	if err != nil {
 		log.Errorf("[%s] Failed to generate alerts endpoint URL: %s", am.Name, err)
 		return err
+	}
+
+	// append query args if mapper needs those
+	queryArgs := mapper.QueryArgs()
+	if queryArgs != "" {
+		url = fmt.Sprintf("%s?%s", url, queryArgs)
 	}
 
 	start := time.Now()

--- a/internal/mapper/mapper.go
+++ b/internal/mapper/mapper.go
@@ -16,6 +16,7 @@ var (
 type Mapper interface {
 	IsSupported(version string) bool
 	AbsoluteURL(baseURI string) (string, error)
+	QueryArgs() string
 }
 
 // AlertMapper handles mapping of Alertmanager alert information to unsee AlertGroup models

--- a/internal/mapper/v04/alerts.go
+++ b/internal/mapper/v04/alerts.go
@@ -59,6 +59,11 @@ func (m AlertMapper) AbsoluteURL(baseURI string) (string, error) {
 	return uri.JoinURL(baseURI, "api/v1/alerts/groups")
 }
 
+// QueryArgs for HTTP requests send to the Alertmanager API endpoint
+func (m AlertMapper) QueryArgs() string {
+	return ""
+}
+
 // IsSupported returns true if given version string is supported
 func (m AlertMapper) IsSupported(version string) bool {
 	versionRange := semver.MustParseRange(">=0.4.0 <0.5.0")

--- a/internal/mapper/v04/silences.go
+++ b/internal/mapper/v04/silences.go
@@ -7,7 +7,9 @@ package v04
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"math"
 	"strconv"
 	"time"
 
@@ -50,6 +52,13 @@ type SilenceMapper struct {
 // AbsoluteURL for silences API endpoint this mapper supports
 func (m SilenceMapper) AbsoluteURL(baseURI string) (string, error) {
 	return uri.JoinURL(baseURI, "api/v1/silences")
+}
+
+// QueryArgs for HTTP requests send to the Alertmanager API endpoint
+func (m SilenceMapper) QueryArgs() string {
+	// Alertmanager 0.4 uses pagination for silences, pass a huge value so that
+	// we get all possible silences
+	return fmt.Sprintf("api/v1/silences?limit=%d", math.MaxInt32)
 }
 
 // IsSupported returns true if given version string is supported

--- a/internal/mapper/v05/alerts.go
+++ b/internal/mapper/v05/alerts.go
@@ -58,6 +58,11 @@ func (m AlertMapper) AbsoluteURL(baseURI string) (string, error) {
 	return uri.JoinURL(baseURI, "api/v1/alerts/groups")
 }
 
+// QueryArgs for HTTP requests send to the Alertmanager API endpoint
+func (m AlertMapper) QueryArgs() string {
+	return ""
+}
+
 // IsSupported returns true if given version string is supported
 func (m AlertMapper) IsSupported(version string) bool {
 	versionRange := semver.MustParseRange(">=0.5.0  <=0.6.0")

--- a/internal/mapper/v05/silences.go
+++ b/internal/mapper/v05/silences.go
@@ -46,6 +46,11 @@ func (m SilenceMapper) AbsoluteURL(baseURI string) (string, error) {
 	return uri.JoinURL(baseURI, "api/v1/silences")
 }
 
+// QueryArgs for HTTP requests send to the Alertmanager API endpoint
+func (m SilenceMapper) QueryArgs() string {
+	return ""
+}
+
 // IsSupported returns true if given version string is supported
 func (m SilenceMapper) IsSupported(version string) bool {
 	versionRange := semver.MustParseRange(">=0.5.0")

--- a/internal/mapper/v061/alerts.go
+++ b/internal/mapper/v061/alerts.go
@@ -60,6 +60,11 @@ func (m AlertMapper) AbsoluteURL(baseURI string) (string, error) {
 	return uri.JoinURL(baseURI, "api/v1/alerts/groups")
 }
 
+// QueryArgs for HTTP requests send to the Alertmanager API endpoint
+func (m AlertMapper) QueryArgs() string {
+	return ""
+}
+
 // IsSupported returns true if given version string is supported
 func (m AlertMapper) IsSupported(version string) bool {
 	versionRange := semver.MustParseRange("=0.6.1")

--- a/internal/mapper/v062/alerts.go
+++ b/internal/mapper/v062/alerts.go
@@ -64,6 +64,11 @@ func (m AlertMapper) AbsoluteURL(baseURI string) (string, error) {
 	return uri.JoinURL(baseURI, "api/v1/alerts/groups")
 }
 
+// QueryArgs for HTTP requests send to the Alertmanager API endpoint
+func (m AlertMapper) QueryArgs() string {
+	return ""
+}
+
 // IsSupported returns true if given version string is supported
 func (m AlertMapper) IsSupported(version string) bool {
 	versionRange := semver.MustParseRange(">=0.6.2")


### PR DESCRIPTION
Alertmanager 0.4.x silences endpoint uses pagination, code for this was incorrectly dropped in #216, re-add it. Requires a way for mapper packages to signal the need for passing query args to HTTP requests