### PR TITLE
Drop the path from v0.4 query args

### DIFF
--- a/internal/mapper/v04/silences.go
+++ b/internal/mapper/v04/silences.go
@@ -58,7 +58,7 @@ func (m SilenceMapper) AbsoluteURL(baseURI string) (string, error) {
 func (m SilenceMapper) QueryArgs() string {
 	// Alertmanager 0.4 uses pagination for silences, pass a huge value so that
 	// we get all possible silences
-	return fmt.Sprintf("api/v1/silences?limit=%d", math.MaxInt32)
+	return fmt.Sprintf("limit=%d", math.MaxInt32)
 }
 
 // IsSupported returns true if given version string is supported


### PR DESCRIPTION
This results in requests to `GET http://localhost:9093/api/v1/silences?api/v1/silences?limit=2147483647` instead of `GET http://localhost:9093/api/v1/silences?limit=2147483647`. Too much copy&paste.