### PR TITLE
Use decoded URI path partial for file paths

### DIFF
--- a/internal/uri/file.go
+++ b/internal/uri/file.go
@@ -32,16 +32,17 @@ func (r *FileURIReader) pathFromURI(uri string) (string, error) {
 		return "", err
 	}
 
-	// if we have a file URI with relative path we need to expand it into an
-	// absolute path, url.Parse doesn't support relative file paths
+	// if we a file URI with an absolute path then return it
 	if strings.HasPrefix(uri, "file:///") {
 		return u.Path, nil
 	}
-	wd, err := os.Getwd()
+	// if we have a file URI with relative path we need to expand it into an
+	// absolute path, url.Parse doesn't support relative file paths
+	cwd, err := os.Getwd()
 	if err != nil {
 		return "", err
 	}
-	absolutePath := path.Join(wd, strings.TrimPrefix(uri, "file://"))
+	absolutePath := path.Join(cwd, u.Host, u.Path)
 	return absolutePath, nil
 }
 

--- a/internal/uri/uri_test.go
+++ b/internal/uri/uri_test.go
@@ -73,6 +73,11 @@ var fileTransportTests = []fileTransportTest{
 		size:   getFileSize("uri.go"),
 		failed: true,
 	},
+	fileTransportTest{
+		uri:    "file://../uri/uri.go",
+		size:   getFileSize("uri.go"),
+		failed: true,
+	},
 }
 
 func readAll(source io.ReadCloser) int64 {


### PR DESCRIPTION
URI passed to the file:// schema handler might contain query args (?limit=10), when we use a relative path we correctly return u.Path, but for absolute paths full uri with stripped schema part was used. Absolute path should be assembled only current dir and path u.Path

This was only affecting Alertmanager `0.4.x` that uses pagination and requires `?limit=N` query args:

```
ERRO[0000] [default] file://internal/mock/0.4.2/api/v1/silences?limit=2147483647 request failed: open Go/src/github.com/cloudflare/unsee/internal/mock/0.4.2/api/v1/silences?limit=2147483647: no such file or directory
```

with this PR reading works correctly:
```
INFO[0000] Reading file '/Users/lukasz/Go/src/github.com/cloudflare/unsee/internal/mock/0.4.2/api/v1/silences'
INFO[0000] [default] Got 3 silences(s) in 314.053µs
```