### PR TITLE
Revert "Tell Travis CI to only build on pushes to the master branch"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ defaults_js: &DEFAULTS_JS
     directories:
       - node_modules
 
-branches:
-  only:
-    - "master"
-
 jobs:
   include:
     - stage: Test Go code


### PR DESCRIPTION
This reverts commit 15a8446588f50c44d4f66812729b9906006261f5.

Limiting build branches to only master has a side effect of not triggering automatic release builds, revert it to Travis defaults since we want release branch jobs.