### PR TITLE
dep prune is depracated, drop it

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -19,6 +19,9 @@
 #  name = "github.com/x/y"
 #  version = "2.4.0"
 
+[prune]
+  go-tests = true
+  unused-packages = true
 
 [[constraint]]
   branch = "master"

--- a/Makefile
+++ b/Makefile
@@ -56,18 +56,15 @@ $(NAME): .build/deps-build-go.ok .build/vendor.ok bindata_assetfs.go $(SOURCES)
 
 .build/vendor.ok: .build/deps-build-go.ok Gopkg.lock Gopkg.toml
 	dep ensure
-	dep prune
 	touch $@
 
 .PHONY: vendor
 vendor: .build/deps-build-go.ok
 	dep ensure
-	dep prune
 
 .PHONY: vendor-update
 vendor-update: .build/deps-build-go.ok
 	dep ensure -update
-	dep prune
 
 .PHONY: webpack
 webpack: .build/artifacts-webpack.ok


### PR DESCRIPTION
dep will now run prune based on the Gopkg.toml settings, add a config for it and drop 'dep prune' from the Makefile