### PR TITLE
Use Go 1.9.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 defaults_go: &DEFAULTS_GO
   language: go
-  go: "1.9.2"
+  go: "1.9.4"
   cache:
     directories:
       - vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN apk add --update make git
 COPY . /unsee
 RUN make -C /unsee webpack
 
-FROM golang:1.9.2-alpine3.6 as go-builder
+FROM golang:1.9.4-alpine3.7 as go-builder
 COPY --from=nodejs-builder /unsee /go/src/github.com/cloudflare/unsee
 ARG VERSION
 RUN apk add --update make git


### PR DESCRIPTION
This switches Travis and Docker builds to use latest stable Go release