### PR TITLE
Use Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 defaults_go: &DEFAULTS_GO
   language: go
-  go: "1.9.2"
+  go: "1.10"
   cache:
     directories:
       - vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN apk add --update make git
 COPY . /unsee
 RUN make -C /unsee webpack
 
-FROM golang:1.9.2-alpine3.6 as go-builder
+FROM golang:1.10-alpine as go-builder
 COPY --from=nodejs-builder /unsee /go/src/github.com/cloudflare/unsee
 ARG VERSION
 RUN apk add --update make git


### PR DESCRIPTION
Use Go 1.10 when testing/releasing on Travis and building docker images.

Note: can't merge yet, we need to wait for new images on https://hub.docker.com/_/golang/