### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS file lists people and teams responsible for code in this
+# repository.
+# See https://help.github.com/articles/about-codeowners/ for details.
+
+* @prymitive


### PR DESCRIPTION
CODEOWNERS allows github to automatically require code review from the right set of people. Start with defaulting to myself for all files