### PR TITLE
fix(mapper): attempt to trim distribution version

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -7,9 +7,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/blang/semver"
 	"github.com/cloudflare/unsee/internal/mock"
 	"github.com/cloudflare/unsee/internal/models"
+	"github.com/cloudflare/unsee/internal/semver"
 )
 
 type groupTest struct {

--- a/internal/mapper/v04/alerts.go
+++ b/internal/mapper/v04/alerts.go
@@ -12,9 +12,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/blang/semver"
 	"github.com/cloudflare/unsee/internal/mapper"
 	"github.com/cloudflare/unsee/internal/models"
+	"github.com/cloudflare/unsee/internal/semver"
 	"github.com/cloudflare/unsee/internal/uri"
 )
 

--- a/internal/mapper/v04/silences.go
+++ b/internal/mapper/v04/silences.go
@@ -13,9 +13,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/blang/semver"
 	"github.com/cloudflare/unsee/internal/mapper"
 	"github.com/cloudflare/unsee/internal/models"
+	"github.com/cloudflare/unsee/internal/semver"
 	"github.com/cloudflare/unsee/internal/uri"
 )
 

--- a/internal/mapper/v05/alerts.go
+++ b/internal/mapper/v05/alerts.go
@@ -11,9 +11,9 @@ import (
 	"sort"
 	"time"
 
-	"github.com/blang/semver"
 	"github.com/cloudflare/unsee/internal/mapper"
 	"github.com/cloudflare/unsee/internal/models"
+	"github.com/cloudflare/unsee/internal/semver"
 	"github.com/cloudflare/unsee/internal/uri"
 )
 

--- a/internal/mapper/v05/silences.go
+++ b/internal/mapper/v05/silences.go
@@ -10,9 +10,9 @@ import (
 	"io"
 	"time"
 
-	"github.com/blang/semver"
 	"github.com/cloudflare/unsee/internal/mapper"
 	"github.com/cloudflare/unsee/internal/models"
+	"github.com/cloudflare/unsee/internal/semver"
 	"github.com/cloudflare/unsee/internal/uri"
 )
 

--- a/internal/mapper/v061/alerts.go
+++ b/internal/mapper/v061/alerts.go
@@ -12,9 +12,9 @@ import (
 	"sort"
 	"time"
 
-	"github.com/blang/semver"
 	"github.com/cloudflare/unsee/internal/mapper"
 	"github.com/cloudflare/unsee/internal/models"
+	"github.com/cloudflare/unsee/internal/semver"
 	"github.com/cloudflare/unsee/internal/uri"
 )
 

--- a/internal/mapper/v062/alerts.go
+++ b/internal/mapper/v062/alerts.go
@@ -12,9 +12,9 @@ import (
 	"sort"
 	"time"
 
-	"github.com/blang/semver"
 	"github.com/cloudflare/unsee/internal/mapper"
 	"github.com/cloudflare/unsee/internal/models"
+	"github.com/cloudflare/unsee/internal/semver"
 	"github.com/cloudflare/unsee/internal/uri"
 )
 

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -1,0 +1,24 @@
+package semver
+
+import (
+	"strings"
+
+	"github.com/blang/semver"
+)
+
+// MustParse is like semver.MustParse, but first attempts to trim
+// distribution metadata from the version string.
+func MustParse(s string) semver.Version {
+	return semver.MustParse(trimDistribution(s))
+}
+
+// MustParseRange is like semver.MustParseRange
+func MustParseRange(s string) semver.Range {
+	return semver.MustParseRange(s)
+}
+
+// trimDistribution attempts to trim the passed version string of
+// and distribution-specific version numbers.
+func trimDistribution(version string) string {
+	return strings.SplitN(version, "~", 2)[0]
+}

--- a/internal/semver/semver_test.go
+++ b/internal/semver/semver_test.go
@@ -1,0 +1,33 @@
+package semver
+
+import (
+	"testing"
+)
+
+func Test_trimDistribution(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "1.2.3",
+			expected: "1.2.3",
+		},
+		{
+			input:    "0.15.0~rc.1~git20180507.28967e3+ds",
+			expected: "0.15.0",
+		},
+		{
+			input:    "foobar",
+			expected: "foobar",
+		},
+	}
+
+	for i, tt := range tests {
+		output := trimDistribution(tt.input)
+
+		if tt.expected != output {
+			t.Errorf("[%d] expected %q got %q", i, tt.expected, output)
+		}
+	}
+}


### PR DESCRIPTION
Unsee supports a range of Alertmanager versions, and maps between the
Alertmanger format and the internal Unsee format using mappers. It
determines what mapper to use by parsing the Alertmanager version on the
assumption it's semver compatible. Some distributions of Alertmanager
append distribution specific metadata to this version string, which the
semver package isn't tolerant of.

This CL creates an internal semver package that sits between Unsee and
the upstream semver package. On calls to `MustParse` it first attempts
to strip the distribution metadata by tossing out everything after the
first tilde.

Bug: #263
Change-Id: I64e66af9ebfe82ae9e55d72f4a049d645a9de299